### PR TITLE
adjust podgateway target annotations and labels

### DIFF
--- a/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
@@ -110,7 +110,7 @@ spec:
         pullPolicy: Always
         tag: v3.9.0
       gatewayDefault: false
-      gatewayLabel: routeToVPN
-      gatewayAnnotation: routeToVPN
+      gatewayLabel: setGateway
+      gatewayAnnotation: setGateway
       namespaceSelector:
         label: "vpn-routed-gateway"


### PR DESCRIPTION
webhook admission controller isn't modifying the target pods. trying the defaults