### PR TITLE
add tunnelPort to cilium config

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -82,6 +82,7 @@ spec:
     ipv4NativeRoutingCIDR: "${CLUSTER_CIDR}"
     k8sServiceHost: 127.0.0.1
     k8sServicePort: 6444
+    tunnelPort: 8469
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:


### PR DESCRIPTION
this is in response to a post in home-cluster discord about having issues with cilum blocking vxlan traffic. I'm having some kind of communication issue with th gateway-init pods that are injected into pods when attempting to come online.