### PR TITLE
disable prune on plex helm chart

### DIFF
--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   path: ./kubernetes/apps/media/plex/app
-  prune: true
+  prune: false
   sourceRef:
     kind: GitRepository
     name: home-kubernetes


### PR DESCRIPTION
plex was working and then uninstall itself according to flux logs:

2024-02-26T22:46:15.895Z info HelmRelease/plex.media - running 'install' action with timeout of 5m0s 2024-02-26T22:51:16.789Z info HelmRelease/plex.media - release is in a failed state