### PR TITLE
add render group 105 to plex supplementalGroups

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
             runAsNonRoot: true
             fsGroup: 568
             fsGroupChangePolicy: OnRootMismatch
-            supplementalGroups: [44, 100]
+            supplementalGroups: [44, 105, 100]
     service:
       main:
         type: LoadBalancer


### PR DESCRIPTION
the group 109 doesn't show up in the container, but it does show 105 next to the /dev/dri device, which is the render group from the host os, debian.