### PR TITLE
remove subsitutefrom vars setting from plex

### DIFF
--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -29,8 +29,3 @@ spec:
       NAMESPACE: *namespace
       VOLSYNC_CAPACITY: 100Gi
       VOLSYNC_CACHE_CAPCITY: 20Gi
-    substituteFrom:
-    - kind: ConfigMap
-      name: cluster-settings
-    - kind: Secret
-      name: cluster-secrets


### PR DESCRIPTION
seems like it can't find the clustervars, maybe that setting is override the higher one?