### PR TITLE
swap to custom pod-gateway pod

### DIFF
--- a/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
@@ -17,8 +17,9 @@ spec:
   #See https://github.com/angelnu/helm-charts/blob/main/charts/apps/pod-gateway/values.yaml
   values:
     image:
-      repository: ghcr.io/angelnu/pod-gateway
-      tag: v1.8.1@sha256:690b6365728fe9012ad4cdfca38334992664596513dca187d1b93d2025205776
+      # repository: ghcr.io/angelnu/pod-gateway
+      repository: jgilfoil/pod-gateway
+      tag: v1.8.2
 
     podAnnotations:
       reloader.stakater.com/auto: "true"


### PR DESCRIPTION
trying to test a fix for an issue where the static ip address set by publicPorts.IP is not used and instead the client_init script pulls a dynamic ip, meaning the forwarding rules don't end up at the correct ip, which means transmission can't get the traffic.