### PR TITLE
clean up the uninstall

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
-      strategy: uninstall
   uninstall:
     keepHistory: false
   dependsOn:


### PR DESCRIPTION
the uninstall was neccessary because there was an immutable field that needed to be updated with the v3 update.