### PR TITLE
reinstall coredns

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
   - ./intel-device-plugin/ks.yaml
   - ./kured/ks.yaml
   - ./kube-vip/ks.yaml
-  # - ./coredns/ks.yaml
+  - ./coredns/ks.yaml


### PR DESCRIPTION
had to add some labels to the existing ServiceAccount used by Coredns so helm could take it over.