### PR TITLE
fix remediation strategy because of

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
+      strategy: uninstall
       retries: 3
   values:
     fullnameOverride: coredns


### PR DESCRIPTION
cannot patch "coredns" with kind Deployment: Deployment.apps "coredns" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"coredns", "app.kubernetes.io/name":"coredns", "k8s-app":"kube-dns"}, MatchExpressions:[]v1.LabelSel │
│ ectorRequirement(nil)}: field is immutable