### PR TITLE
adjust kube-dns service name

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
     fullnameOverride: *app
     priorityClassName: "system-cluster-critical"
     replicaCount: 2
-    k8sAppLabelOverride: kube-dns
+    k8sAppLabelOverride: kube-dns-interim
     serviceAccount:
       create: true
     service:


### PR DESCRIPTION
can't overlap with existing coredns