### PR TITLE
revert gluten back to 3.37

### DIFF
--- a/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
         gluetun:
           image:
             repository: docker.io/qmcgaw/gluetun
-            tag: v3.38.0@sha256:5522794f5cce6d84bc7f06b1e3a3b836ede9100c64aec94543cb503bb2ecb72f
+            tag: v3.37.0@sha256:ba9688ff9abaf73bbc0b257be547b51a097ca74324fedddeeb709732c2692eef
 
         env:
         # - name:  VPN_SERVICE_PROVIDER


### PR DESCRIPTION
pods aren't able to connect to the pod gateway currently. GATEWAY_IP=';; UDP setup with 10.96.0.10#53(10.96.0.10) for vpn-gateway-pod-gateway.network.svc.cluster.local failed: permission denied.