### PR TITLE
shift volsync backups to once per day at 4am.

### DIFF
--- a/kubernetes/templates/volsync/replicationsource.yaml
+++ b/kubernetes/templates/volsync/replicationsource.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   sourcePVC: "${APP}"
   trigger:
-    schedule: "0 */4 * * *"
+    schedule: "0 4 * * *" 
   restic:
     copyMethod: Snapshot
     pruneIntervalDays: 3
@@ -21,7 +21,6 @@ spec:
       runAsGroup: 568
       fsGroup: 568
     retain:
-      hourly: 9
       daily: 7
       weekly: 3
       monthly: 3


### PR DESCRIPTION
My reasoning for this is i don't actually need ever four hour backups on this stuff, it's not changing that much. Additionally, i'm worried it's impacting the kured os restarts when trying to cordon a node if this is running at the same time. Also, i don't need the wear and tear on my drives.