### PR TITLE
disable alert manager

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
       enabled: true
     cleanPrometheusOperatorObjectNames: true
     alertmanager:
+      enabled: false
       ingress:
         enabled: true
         pathType: Prefix


### PR DESCRIPTION
going to redeploy, as it's not picking up the config i think it should and i can't be sure why