### PR TITLE
adjust minio alert manager scheme to capitalize

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./helmrelease.yaml
   - ./secret.sops.yaml
   - ./scrapeconfig.yaml
+  - ./minio-bearer.secret.sops.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/minio-bearer.secret.sops.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/minio-bearer.secret.sops.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: minio-bearer
+type: Opaque
+stringData:
+    token: ENC[AES256_GCM,data:cL/zfbOdrHq404xeRRIyAcuXSc9sM7f5OFyItmIUCmVto1Vl6wh2WN5EBVY0NqC3oJwVxx6klrveYWfFGx8mWthzHGwRHxCtRnZ0ngJRfbpL2JYyXcGEDojHjTXD4BLtXftaAxc7GkWW6ERa2bosQjPq5EANgkDm87ishmF56hUQJKFjPIKZ/2OtEBl7QEXykg0OmoC+fUVCR24L7C2p95LFLh9Ky2j/9oFsL18gu+AqLiE9bncXN8eNXM7dUJP0pSWrPPprqVI=,iv:3+rBHDX6z/PXQ9J5VgCmLNCavrTB0AZs2QoYOl59jNk=,tag:AnuzbSue9m9RI2gz8hDAZQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age12rzrdtn8xhd89y23qw4kymxftuylqn5cm522jcn327atent4a40swjcgmj
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFcFhxdnpYNWlaS0pyMS9h
+            YWI4c05PcWRzS1pvdEk0VklwaTJWV0hkc1Z3CjFTakNnbkJZcGRqYjY2MW9wUThh
+            R1BqVzVkZmdYeVhzTC9WcWZOSER1N3cKLS0tIGoxRTRMKzR3Q0V0dXNmU2VJZ3Js
+            d0wvdk9jKy9ncklKekZNYWlKMWJvaTAKSWyK0N4wEVhhRq4wJbXZvKQsEPouNnxN
+            w2Mp+yYk6Wozd5EWQm/LTDTmB2nyR8LGOSdGIQHTKY/nxmwEl/dV8w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-04-22T03:11:56Z"
+    mac: ENC[AES256_GCM,data:UfoPMxKBmi3nEQ0aC7cLXEri2Vqm1DDRCgKr88+qhxQ0GnAFMzDNgrq14OyncFySJIVu9G6RC4aT2e7CD64WIobOVGGaMGZwi3ln43X3ZoUwR1zEBYYQ9TjRw1OX34mJCOPxKdEdpgDtd6IHVJkgeAbdJiT/uFo3iogLlzCrZLg=,iv:Spfep36Nq9Umvw3+K3LhyH1DL6a8o8S7sq6yt7iQKVE=,tag:2fJC9bZe8X9NlAIaDec8Ag==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
@@ -4,7 +4,6 @@ kind: ScrapeConfig
 metadata:
   name: minio-scrape
 spec:
-  jobName: minio-job
   scheme: HTTP
   bearerToken: "{{MINIO_BEARER_TOKEN}}"
   metricsPath: /minio/v2/metrics/cluster

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
@@ -5,7 +5,7 @@ metadata:
   name: minio-scrape
 spec:
   jobName: minio-job
-  scheme: http
+  scheme: HTTP
   bearerToken: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJwcm9tZXRoZXVzIiwic3ViIjoidjNadTNWU0kyVGUiLCJleHAiOjQ4NjczNTIwMTZ9.I_pmkXvepJDEMGjL8zC0Fulajf7adPEyjhqK7RxWql3vbuZI7E2LdtqoMNXimFcciyEApZbgxe3fQN55TBqmVA
   metricsPath: /minio/v2/metrics/cluster
   staticConfigs:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
@@ -1,11 +1,14 @@
----
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
   name: minio-scrape
 spec:
   scheme: HTTP
-  bearerToken: "{{MINIO_BEARER_TOKEN}}"
+  authorization:
+    type: Bearer
+    credentials:
+      name: minio-secret
+      key: token
   metricsPath: /minio/v2/metrics/cluster
   staticConfigs:
     - targets:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   jobName: minio-job
   scheme: HTTP
-  bearerToken: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJwcm9tZXRoZXVzIiwic3ViIjoidjNadTNWU0kyVGUiLCJleHAiOjQ4NjczNTIwMTZ9.I_pmkXvepJDEMGjL8zC0Fulajf7adPEyjhqK7RxWql3vbuZI7E2LdtqoMNXimFcciyEApZbgxe3fQN55TBqmVA
+  bearerToken: "{{MINIO_BEARER_TOKEN}}"
   metricsPath: /minio/v2/metrics/cluster
   staticConfigs:
     - targets:

--- a/kubernetes/flux/vars/cluster-secrets.sops.yaml
+++ b/kubernetes/flux/vars/cluster-secrets.sops.yaml
@@ -4,17 +4,18 @@ metadata:
     name: cluster-secrets
     namespace: flux-system
 stringData:
-    SECRET_DOMAIN: ENC[AES256_GCM,data:m0VMaivxsZhOi6s=,iv:koiCmy5HBx+Yg+uViFjD+yU49k1sQmCtXM7zhRZPIdg=,tag:5rMVKJLsJR/7u6FRzsH4AQ==,type:str]
-    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:zQM8bVo1W5R2aOqcvbR1dMIK,iv:7MAfC9sUOOSpYDUqLgRGAAJyLQY9GD6jFTISdrEi9bY=,tag:7ZECnHe2o3/TeZLbMPXkcg==,type:str]
-    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:hibGipAXnNbLxUVAJdmr7f3Xk8Ndcla4B6dipgPffycW81mM,iv:xjYABnZ7b+cOQ7vtQPya3yUgAhZ1MSKHFUweOfIKrRc=,tag:2sbseXz715lND2JuVxslPw==,type:str]
-    RESTIC_REPOSITORY_URL: ENC[AES256_GCM,data:CLru/hRZMy+7QpTHYt4LaJGqhCEI3LLVbBFJuGcdvEFQ/uAc7ubKGSwpy2/g0g==,iv:GYwW8/8ijHoDbqrrIZxfxzMtKDPLuxxDyz7ZijjMo4c=,tag:PP577CUPd2So+IrV0kbmoQ==,type:str]
-    RESTIC_REPOSITORY_ENCRYPTION_KEY: ENC[AES256_GCM,data:+kl440gtAsqjKQPQ/Uu9ZA==,iv:5mgnAVfBd+Kd4Rum7V83VirhYey9yBra3bcP86HxWGs=,tag:X5/SvDYk3EyAO7YHnaREDg==,type:str]
-    RESTIC_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:EGzEWyVMwdcoUGTLaRhTKQ==,iv:C1fRuUsZ6wu6tdMA6Uc8QD2Pts+X/ySBxK2nU6Mip3U=,tag:Nd17R2aQYkiH7qAG0CHO+w==,type:str]
-    RESTIC_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:vG0zyOeJlNwMBYIpYPNULZltHos0n7pSP9TKjAFPmlE=,iv:SZrxQt0/rIG2/Um5olpgHIWe+bOQ1Eacza24l8SVFQw=,tag:UO+5RCBbvcB3KwYjtckNHA==,type:str]
-    SECRET_VPN_GATEWAY_PORT: ENC[AES256_GCM,data:tc+t7Q==,iv:xRRwxEc33q9r6YMllXXN9J7XxWxCftoK/yf1HzloQME=,tag:sWYe8azuF7tbcoKlqDO7kw==,type:str]
-    SECRET_TRANSMISSION_RPC_PASSWORD: ENC[AES256_GCM,data:VlHlO35ksvuvXrVQUKCCSA==,iv:ZpjlqmObnPOuVWIl4gF922PLBPn9du4pHma0qAIwJzg=,tag:IecRO+zrvaIfD+fvpvf1Mw==,type:str]
-    NAS_ADDR: ENC[AES256_GCM,data:heeqopJ8HSgkOlwO,iv:Q+bRwuJSPi8j3Wfz5Ac+JBAg7htdv37DAWNIDZjXiM4=,tag:MAFVAVz1jRhA/7XfIyP3Ig==,type:str]
-    PRIMARY_DNS: ENC[AES256_GCM,data:OmeYaMh44HFpQlynXw==,iv:jrkh+9CwU3AxNlWsuixL4Rbm/kLwOGA5y8PUEb/+1OA=,tag:5U5Q3IIANSOaNxW8trv1SQ==,type:str]
+    SECRET_DOMAIN: ENC[AES256_GCM,data:p/s8txkV6RxrHNU=,iv:gWfjjMZ3GUc2Dj7jSdnagqAqTnO7r6bp5269KSimEVc=,tag:dkjvsu9AUR5Ri8pXc3Louw==,type:str]
+    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:3MTyDVF0h+H7eQ7QWpVEF+wx,iv:SmLAv7AmX7j1rDFz9Cjw7m6EjCspPd1Pxl/znZ/MfpI=,tag:WjYYt5QZzgKcyBfUv+0PxQ==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:SwP7drIJ0hLU27AFwL2CEKL0YA+HNyubGDKcPAbuQhZJgJzE,iv:L/pXcA23zeZYSHJzh4Dif0YhZee4LrhXQurBsU33H68=,tag:dt3+Ds2MnKrY7VNETAPJLw==,type:str]
+    RESTIC_REPOSITORY_URL: ENC[AES256_GCM,data:O3Wa97dWAO9YQgYdHpNJTDrty8mTLPdQnTNGKIE55bdAF93tKaEbRtS/nKDwyw==,iv:/0shF4k5VLKy8P6uqcJ3jakNJ+u+n0y/6LmdWRgK654=,tag:DAmEuvLTmnaIjRHGO3QpzA==,type:str]
+    RESTIC_REPOSITORY_ENCRYPTION_KEY: ENC[AES256_GCM,data:J9UeIBcdWBj7l8ZXeHwUsw==,iv:QNnilY7B3Wxq4z95l5AyV3PRv5dqNPde2v/Z8cRf+Nk=,tag:o0qRbdJb5QVR5kjZ/6IDBg==,type:str]
+    RESTIC_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:lUV2DXFxAB79zGdwjCjxFw==,iv:eRiFdU13mIONR4MPQ7rwYqRRhc93pIdbXvFhql6RMyk=,tag:i/Dfr0igH3Bgma3Jb2oQYA==,type:str]
+    RESTIC_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Dr8ZvQaqcu0s7cxzhMdHtyGqKeUvN7SWdwuaDlPFySc=,iv:W4VoF8grKK//O23flok1Go6X0s6Q5DzjVj0kID5kRh4=,tag:D3rtCsPRJ+5HCiWtTLf1Vw==,type:str]
+    SECRET_VPN_GATEWAY_PORT: ENC[AES256_GCM,data:awc1Og==,iv:W15lMFkrNeFcNIhHNjJnidjUVuxM0PHSxmQiSWg2OKY=,tag:bCUPSZ1GA16K2G+qbaDuNA==,type:str]
+    SECRET_TRANSMISSION_RPC_PASSWORD: ENC[AES256_GCM,data:Ys5NHp1hnisxUxQf9ooipQ==,iv:JvQ9l2TNSjyIFCW79eQdm0sWzR7Nrv6vYI3R98vNJ2k=,tag:uiKgZbexcLtDRbIU0szVTg==,type:str]
+    NAS_ADDR: ENC[AES256_GCM,data:J2HZwTh/QxZS9izg,iv:jzPp1/6DFWc6N9lTuBfYD91+eZT0Owa5hHbc3Zd1tnI=,tag:DZBcUWxizaYuqt5idRIyvg==,type:str]
+    PRIMARY_DNS: ENC[AES256_GCM,data:fV0yhiYA7z0qTr22jA==,iv:oExAx73rglZH6DZaWgemFlIzXKWKJXbRZXMfhmPjnb0=,tag:lVog6ZIqDh58BHv6odIlBg==,type:str]
+    MINIO_BEARER_TOKEN: ENC[AES256_GCM,data:4d2Eme9nvPVnS8lUqq+ayMWqw44DtBPIOKmAnsj2hqdBTr3UDBKHwyPssG2aXj5iyRB4e4+m0xiJ7Lv+vP697Qhc3y3ez7ztcZccij7HWY0Q/V8VkN/vnBa/nQANoLyqiK9kIAa5q3fJLgzUck8KfYI0CmgreSdHjqfLO38OSVAIuMgoZO5PitORBeYW1Btma193Byjm330quXEPMjrc/meZXbukf+Upv0eV7kJ71IQqyNaBoZmtQ+PIERjE1MCYJplvud+0J+o=,iv:U0poJPiErh/M0WlSNgTbwja2mR9Qu9TgtaSJn64t74U=,tag:K0SZBZOFWc1P3/55mbvunQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -24,14 +25,14 @@ sops:
         - recipient: age12rzrdtn8xhd89y23qw4kymxftuylqn5cm522jcn327atent4a40swjcgmj
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZQXdpZXRhNW9Lb0dGdmR6
-            MXAxU0lGa1NzQkhrRUJ3YURSMXRmdDExbFJ3CndRY2hHMnZzZ2V5bk1YYjlkOFNI
-            MlB4MUVWNXZPSzJnQzMvYm14dTVTUDgKLS0tIDIzUElnNi80YW9rVlR2clVFY3U5
-            NndsMHYwalFUMEs0Y0JhMFo2MEkwbXMKv0xXclQ/C6AMs4SblSyP+vSYpZSfJgmy
-            I60J8Bbs33VgfCBuHQz+RvXoczMhRXaQJxdpsBz8N0y1C4N5mBqnbA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwam5ZakdqYzRNdERoOGsv
+            NU9hVkVSemdZcUJxSTJnSTBMMnBFTFFPR3dRCkhmaWx2Szl5S2NlemJYZUJOSFhr
+            cVp6UXIxRFJQT1BSZFhTY2ZpNE9CSDgKLS0tIGRwZ1hTRVo5QTRwcTZiYzRQSXB5
+            dUpZamt5OHhCU1VPYzc3R3o0d1lhM28KAgOCrIlhXIhfngdRbUAeYIBY/5iaHLiV
+            Lyskuun587OvSj75t8A8NM+5G5QL7W5rwH6rERozKzIGUz4y53slRA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-03-24T23:32:15Z"
-    mac: ENC[AES256_GCM,data:CNeJ8XXpXl1TrvRLWkvaFralyLlerwKM/aDfwIh/qa0XCuHbAjvIm0in18HqWB6g4cS56t+enkpPGYsYE6CmwHTxxtCfGsDFb5esV/n1uEW56ot8b/0jYktiXp0AS6RZFhzQqJ63XgOwKObXFHjTKo/frkph1dU1u6sAHGCobDw=,iv:o5ERWLxYbpgLJdAE/f3PbA4Ui5f0yvzLJljuNgV4gWE=,tag:rinMOMjbON3vqAC/iCITTg==,type:str]
+    lastmodified: "2024-04-22T02:49:42Z"
+    mac: ENC[AES256_GCM,data:gyHvhxUFEtA1847iteXJUPhqlJO5Ja/l2bASfT8RCJ0BXHJJe3iYBF57ieTYq1L4m7Xs5HefPuzugLS8y6s9zjGY/EO4idYwNSBBSvlGsoNGA6NklYyUGmV/O6j2iwUdwXbNsUef6VmLCyvYven6e4VIpaUrdBon6SlQ9noFIWw=,iv:3Cxo272kr8oAJQnzBE0repbp/vl5mID+OO/FzBtFCwc=,tag:ujY14P8IjRC2Ksnh31WU/g==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1

--- a/kubernetes/flux/vars/cluster-secrets.sops.yaml
+++ b/kubernetes/flux/vars/cluster-secrets.sops.yaml
@@ -4,18 +4,17 @@ metadata:
     name: cluster-secrets
     namespace: flux-system
 stringData:
-    SECRET_DOMAIN: ENC[AES256_GCM,data:p/s8txkV6RxrHNU=,iv:gWfjjMZ3GUc2Dj7jSdnagqAqTnO7r6bp5269KSimEVc=,tag:dkjvsu9AUR5Ri8pXc3Louw==,type:str]
-    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:3MTyDVF0h+H7eQ7QWpVEF+wx,iv:SmLAv7AmX7j1rDFz9Cjw7m6EjCspPd1Pxl/znZ/MfpI=,tag:WjYYt5QZzgKcyBfUv+0PxQ==,type:str]
-    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:SwP7drIJ0hLU27AFwL2CEKL0YA+HNyubGDKcPAbuQhZJgJzE,iv:L/pXcA23zeZYSHJzh4Dif0YhZee4LrhXQurBsU33H68=,tag:dt3+Ds2MnKrY7VNETAPJLw==,type:str]
-    RESTIC_REPOSITORY_URL: ENC[AES256_GCM,data:O3Wa97dWAO9YQgYdHpNJTDrty8mTLPdQnTNGKIE55bdAF93tKaEbRtS/nKDwyw==,iv:/0shF4k5VLKy8P6uqcJ3jakNJ+u+n0y/6LmdWRgK654=,tag:DAmEuvLTmnaIjRHGO3QpzA==,type:str]
-    RESTIC_REPOSITORY_ENCRYPTION_KEY: ENC[AES256_GCM,data:J9UeIBcdWBj7l8ZXeHwUsw==,iv:QNnilY7B3Wxq4z95l5AyV3PRv5dqNPde2v/Z8cRf+Nk=,tag:o0qRbdJb5QVR5kjZ/6IDBg==,type:str]
-    RESTIC_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:lUV2DXFxAB79zGdwjCjxFw==,iv:eRiFdU13mIONR4MPQ7rwYqRRhc93pIdbXvFhql6RMyk=,tag:i/Dfr0igH3Bgma3Jb2oQYA==,type:str]
-    RESTIC_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Dr8ZvQaqcu0s7cxzhMdHtyGqKeUvN7SWdwuaDlPFySc=,iv:W4VoF8grKK//O23flok1Go6X0s6Q5DzjVj0kID5kRh4=,tag:D3rtCsPRJ+5HCiWtTLf1Vw==,type:str]
-    SECRET_VPN_GATEWAY_PORT: ENC[AES256_GCM,data:awc1Og==,iv:W15lMFkrNeFcNIhHNjJnidjUVuxM0PHSxmQiSWg2OKY=,tag:bCUPSZ1GA16K2G+qbaDuNA==,type:str]
-    SECRET_TRANSMISSION_RPC_PASSWORD: ENC[AES256_GCM,data:Ys5NHp1hnisxUxQf9ooipQ==,iv:JvQ9l2TNSjyIFCW79eQdm0sWzR7Nrv6vYI3R98vNJ2k=,tag:uiKgZbexcLtDRbIU0szVTg==,type:str]
-    NAS_ADDR: ENC[AES256_GCM,data:J2HZwTh/QxZS9izg,iv:jzPp1/6DFWc6N9lTuBfYD91+eZT0Owa5hHbc3Zd1tnI=,tag:DZBcUWxizaYuqt5idRIyvg==,type:str]
-    PRIMARY_DNS: ENC[AES256_GCM,data:fV0yhiYA7z0qTr22jA==,iv:oExAx73rglZH6DZaWgemFlIzXKWKJXbRZXMfhmPjnb0=,tag:lVog6ZIqDh58BHv6odIlBg==,type:str]
-    MINIO_BEARER_TOKEN: ENC[AES256_GCM,data:4d2Eme9nvPVnS8lUqq+ayMWqw44DtBPIOKmAnsj2hqdBTr3UDBKHwyPssG2aXj5iyRB4e4+m0xiJ7Lv+vP697Qhc3y3ez7ztcZccij7HWY0Q/V8VkN/vnBa/nQANoLyqiK9kIAa5q3fJLgzUck8KfYI0CmgreSdHjqfLO38OSVAIuMgoZO5PitORBeYW1Btma193Byjm330quXEPMjrc/meZXbukf+Upv0eV7kJ71IQqyNaBoZmtQ+PIERjE1MCYJplvud+0J+o=,iv:U0poJPiErh/M0WlSNgTbwja2mR9Qu9TgtaSJn64t74U=,tag:K0SZBZOFWc1P3/55mbvunQ==,type:str]
+    SECRET_DOMAIN: ENC[AES256_GCM,data:G2YdwT+BS+jXOd4=,iv:xd4eVooyqXT37Ih4pSywq5x0gCwPJVA9dikglbcoWc8=,tag:Da8keD5nkBqz/PdClDHjZQ==,type:str]
+    SECRET_ACME_EMAIL: ENC[AES256_GCM,data:7gQ4iVBa9Aw80qq6Sbte7A0f,iv:eO4lcUa+BNrcjvr+wU73N0H3zlQKx8oUhyGBLaiKoW0=,tag:V/GVsrFSgdJvrIshKxERPA==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:6CRYJAGQWWV61XjmWvrQGISOmuGPB93y8KAg/xP3E/5nj5LV,iv:cFPKOHiusWArLhSpC2twcwh+jbG9hOiFc5kGzi1tkRo=,tag:7jETz49gR8u8jKTN1u+gHg==,type:str]
+    RESTIC_REPOSITORY_URL: ENC[AES256_GCM,data:Gw75aOzVfeHhFUI/UCSMDwYZamlCA3JwmSbc6/MbRmPL1RGeL+DmvpFWeAsc8g==,iv:DWmttdfxG9EjYvJbb+4CCu8MIKmQ3jS0sI3WdzrJ/+M=,tag:cz8R0I0YHGM4ZVP4irRNJA==,type:str]
+    RESTIC_REPOSITORY_ENCRYPTION_KEY: ENC[AES256_GCM,data:ANlXhxp0a8d8/Aj62z+OhQ==,iv:zGfgIoXgAshAPRewHSeQUs6uq3sIrQ/TKmJ1Lnt0J8k=,tag:lRLIzgU2H6PGADj5Phddmw==,type:str]
+    RESTIC_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:DGCSOpkSu+IiqUWZSBc8lQ==,iv:oGZnAKQmKgJEwQvTiSq/gWI+61AwHdHFZSRsFUrfT/o=,tag:bAoRxlx3eslhj/YDT/51BA==,type:str]
+    RESTIC_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:kZJ6CrQrPIBftW89gQQOZCaQYDMJwUSRronN1kbEvaA=,iv:T2sz0HTGZWpLs3WcOst0bugg/GutqRoDxg9JlFeSJDY=,tag:8og4QTgxP8a7MGbSD2H6HQ==,type:str]
+    SECRET_VPN_GATEWAY_PORT: ENC[AES256_GCM,data:rP+rMQ==,iv:ocVCZR9fJHs04qJKQ94iD+/PDdlkOZY4PbESn7yKdNY=,tag:YG6w7jfqqHvTFiPXfjUYFA==,type:str]
+    SECRET_TRANSMISSION_RPC_PASSWORD: ENC[AES256_GCM,data:aBQZuro9aiCu5knpi3da3A==,iv:b1PakN3MWC3+3zL9G2LW2iLAgmP4ETdjBpGukV55vYA=,tag:T/D1D5rIBwI/eq4KmCAEnA==,type:str]
+    NAS_ADDR: ENC[AES256_GCM,data:D7S7qZ659ndV7zCf,iv:Hz05F+lZM/DD3NZqGw4Ys3RPdQohOblLUCyjbHmSjc4=,tag:WvH69NBYAPHQFHjdz1L1bw==,type:str]
+    PRIMARY_DNS: ENC[AES256_GCM,data:HSIrHrLI2QmcM2zHwA==,iv:g26o8dlKhg9BIyQ2lLOrFidJ5KFsV8lDA6rE+Lw2FWs=,tag:0kK/7xaW5K3UjiBiWZxbag==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -25,14 +24,14 @@ sops:
         - recipient: age12rzrdtn8xhd89y23qw4kymxftuylqn5cm522jcn327atent4a40swjcgmj
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwam5ZakdqYzRNdERoOGsv
-            NU9hVkVSemdZcUJxSTJnSTBMMnBFTFFPR3dRCkhmaWx2Szl5S2NlemJYZUJOSFhr
-            cVp6UXIxRFJQT1BSZFhTY2ZpNE9CSDgKLS0tIGRwZ1hTRVo5QTRwcTZiYzRQSXB5
-            dUpZamt5OHhCU1VPYzc3R3o0d1lhM28KAgOCrIlhXIhfngdRbUAeYIBY/5iaHLiV
-            Lyskuun587OvSj75t8A8NM+5G5QL7W5rwH6rERozKzIGUz4y53slRA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMMkJiaTR6MFZVeW5jOTEy
+            NWdqZUhEbWF1TityclZUODlvS0I0ZkVoM1dFCksyc0V6VkVtLzNLTy9vUjRSWVM1
+            cTE0emZ3ODl6alZrTkRkZ0lRZEVyVzQKLS0tIE5sbG1sVDFyKzhBUVorNDVDdlZ0
+            TTdSQnlMdG41MjZhR29DNWc5ZVR2SlkK1oUpsrvlaHLsdDrap2KYz7OsmHwC/qBt
+            HhuZTrLos4ZgOGtmWd7RjAt/l9o9Xsv+2bcvNbtg6O2Hmo3Kre24og==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-04-22T02:49:42Z"
-    mac: ENC[AES256_GCM,data:gyHvhxUFEtA1847iteXJUPhqlJO5Ja/l2bASfT8RCJ0BXHJJe3iYBF57ieTYq1L4m7Xs5HefPuzugLS8y6s9zjGY/EO4idYwNSBBSvlGsoNGA6NklYyUGmV/O6j2iwUdwXbNsUef6VmLCyvYven6e4VIpaUrdBon6SlQ9noFIWw=,iv:3Cxo272kr8oAJQnzBE0repbp/vl5mID+OO/FzBtFCwc=,tag:ujY14P8IjRC2Ksnh31WU/g==,type:str]
+    lastmodified: "2024-04-22T03:11:28Z"
+    mac: ENC[AES256_GCM,data:6Ml5biPr/fgROglqLOppQ8jwfHChk9nOolQMyH6yrERw+w5kASJIlwpEln9TAVkJaCfVrpxucJ4o8kpTySPAnqJGTBxWnYKLW1r+aVzRby/u9K+o1CPm51nsDyp4q+g+iFlGyeysJuASfwuDSXdw5kd8Ws39tYEFVlwIa4vETLc=,iv:OAplbg59t9SGNEhoe1+fVuGZbjpr/mbvNn92Y3PjVuk=,tag:owTyQxSycnD/+Nvt7ZqWfQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
stdin - ScrapeConfig minio-scrape is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/scheme' does not validate with https://kubernetes-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json#/properties/spec/properties/scheme/enum: value must be one of "HTTP", "HTTPS"