### PR TITLE
remove kube-vip temporarily

### DIFF
--- a/kubernetes/apps/kube-system/kube-vip/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kube-vip/app/kustomization.yaml
@@ -3,4 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./rbac.yaml
-  - ./daemonset.yaml
+  # - ./daemonset.yaml


### PR DESCRIPTION
having serious issues with kube-vip where the currently elected vip leader can't do health checks on pods. trying a reinstall.