### PR TITLE
rollback changes to gluetun

### DIFF
--- a/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
         gluetun:
           image:
             repository: docker.io/qmcgaw/gluetun
-            tag: v3.39.0@sha256:2f011a9aca767af62008d879eefcbc80a8645bd4fd4466ab312cc941cb658ad1
+            tag: v3.38.0@sha256:5522794f5cce6d84bc7f06b1e3a3b836ede9100c64aec94543cb503bb2ecb72f
 
         env:
         # - name:  VPN_SERVICE_PROVIDER


### PR DESCRIPTION
broke pods relying on the vpn.