### PR TITLE
add sref react configmap setting for dev mmia discord bot

### DIFF
--- a/kubernetes/apps/mymindinai/discordbot/dev/configmap.yaml
+++ b/kubernetes/apps/mymindinai/discordbot/dev/configmap.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   LOG_LEVEL: "DEBUG"
   EMOJI_STRING: "🧪"
+  SREF_REACT: "🧑"


### PR DESCRIPTION
We need to be able to test the bot with separate emoji's from prod config.