### PR TITLE
fix(financial-planner): add writable /tmp volume for nginx PID file

### DIFF
--- a/kubernetes/apps/default/financial-planner/app/helmrelease.yaml
+++ b/kubernetes/apps/default/financial-planner/app/helmrelease.yaml
@@ -54,6 +54,11 @@ spec:
             fsGroup: 10001
           imagePullSecrets:
             - name: ghcr-login-secret
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
     service:
       app:
         controller: *app


### PR DESCRIPTION
- Add emptyDir persistence volume mounted at /tmp
- Resolves nginx startup error: 'open() "/tmp/nginx.pid" failed (30: Read-only file system)'
- Required for containers with readOnlyRootFilesystem: true security setting

This allows nginx to write its PID file while maintaining security hardening.