### PR TITLE
fix(notifications): temporarily mute flux notifications vpn-gateway

### DIFF
--- a/kubernetes/apps/flux-system/notifications/discord/notifications.yaml
+++ b/kubernetes/apps/flux-system/notifications/discord/notifications.yaml
@@ -30,6 +30,9 @@ spec:
     - kind: HelmRelease
       name: "*"
   exclusionList:
+    # Temporary mute: vpn-gateway is currently failing health checks; don't spam Discord.
+    - "kustomization/vpn-gateway\\.flux-system"
+    - "helmrelease/vpn-gateway\\.network"
     - "error.*lookup github\\.com"
     - "waiting.*socket"
   suspend: false


### PR DESCRIPTION
the alert is being caused by a deprecated chart and i'm not ready to update it yet if there's conflicts/issues. Will undo once the new version is in place.