### PR TITLE
fix(notifications): update exclusion patterns for vpn-gateway alerts

### DIFF
--- a/kubernetes/apps/flux-system/notifications/discord/notifications.yaml
+++ b/kubernetes/apps/flux-system/notifications/discord/notifications.yaml
@@ -31,8 +31,9 @@ spec:
       name: "*"
   exclusionList:
     # Temporary mute: vpn-gateway is currently failing health checks; don't spam Discord.
-    - "kustomization/vpn-gateway\\.flux-system"
-    - "helmrelease/vpn-gateway\\.network"
+    # Note: exclusionList matches against the event message; match the strings that actually appear there.
+    - "(?i)kustomization/vpn-gateway"
+    - "(?i)helmrelease/network/vpn-gateway"
     - "error.*lookup github\\.com"
     - "waiting.*socket"
   suspend: false


### PR DESCRIPTION
Refine the exclusion list in Discord notifications to use case-insensitive regex patterns for better matching of event messages related to the vpn-gateway.