### PR TITLE
[codex] add safe cluster MCP server

### DIFF
--- a/.codex/config.toml.example
+++ b/.codex/config.toml.example
@@ -1,0 +1,29 @@
+[mcp_servers.home-cluster]
+command = "python3"
+args = [
+  "-m",
+  "home_cluster_mcp",
+  "--config",
+  "/home/jason/repos/home-cluster/tools/home-cluster-mcp/config.sample.yaml",
+]
+cwd = "/home/jason/repos/home-cluster/tools/home-cluster-mcp"
+env = { PYTHONPATH = "/home/jason/repos/home-cluster/tools/home-cluster-mcp/src" }
+enabled = true
+startup_timeout_sec = 10
+tool_timeout_sec = 60
+default_tools_approval_mode = "auto"
+enabled_tools = [
+  "cluster_overview",
+  "flux_status",
+  "recent_events",
+  "workload_status",
+  "pod_summary",
+  "pod_logs",
+  "resource_git_hint",
+  "prometheus_query",
+  "pod_exec_plan",
+  "pod_exec",
+]
+
+[mcp_servers.home-cluster.tools.pod_exec]
+approval_mode = "approve"

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ kubeconfig
 .bin
 # Ansible
 .venv*
+# Python
+__pycache__/
+.pytest_cache/
 # Taskfile
 .task
 # Brew

--- a/.taskfiles/Mcp/Taskfile.yaml
+++ b/.taskfiles/Mcp/Taskfile.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  MCP_DIR: "{{.ROOT_DIR}}/tools/home-cluster-mcp"
+  MCP_CONFIG_FILE: "{{.MCP_DIR}}/config.sample.yaml"
+  MCP_PRIVATE_DIR: "{{.PRIVATE_DIR}}/codex-mcp"
+  MCP_KUBECONFIG_FILE: "{{.MCP_PRIVATE_DIR}}/kubeconfig"
+
+tasks:
+
+  install:
+    desc: Install the home-cluster MCP package and test extras
+    cmd: '{{.PYTHON_BIN}} -m pip install --upgrade --editable "{{.MCP_DIR}}[test]"'
+    preconditions:
+      - { msg: "Missing MCP package", sh: "test -f {{.MCP_DIR}}/pyproject.toml" }
+
+  kubeconfig:
+    desc: Create a short-lived kubeconfig for the Codex MCP service account
+    cmds:
+      - mkdir -p "{{.MCP_PRIVATE_DIR}}"
+      - |
+        set -eu
+        TOKEN="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" -n default create token codex-mcp --duration=8h)"
+        SERVER="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" config view --raw --minify -o jsonpath='{.clusters[0].cluster.server}')"
+        CA_DATA="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')"
+        if [ -z "$CA_DATA" ]; then
+          echo "Current kubeconfig does not expose certificate-authority-data with --raw --minify" >&2
+          exit 1
+        fi
+        umask 077
+        cat > "{{.MCP_KUBECONFIG_FILE}}" <<EOF
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: home-cluster
+          cluster:
+            server: ${SERVER}
+            certificate-authority-data: ${CA_DATA}
+        users:
+        - name: codex-mcp
+          user:
+            token: ${TOKEN}
+        contexts:
+        - name: codex-mcp@home-cluster
+          context:
+            cluster: home-cluster
+            user: codex-mcp
+            namespace: default
+        current-context: codex-mcp@home-cluster
+        EOF
+        chmod 600 "{{.MCP_KUBECONFIG_FILE}}"
+        echo "Wrote {{.MCP_KUBECONFIG_FILE}}"
+    preconditions:
+      - { msg: "Missing kubectl", sh: "command -v kubectl" }
+      - { msg: "Missing kubeconfig", sh: "test -f {{.KUBECONFIG_FILE}}" }
+
+  run:
+    desc: Run the home-cluster MCP stdio server locally
+    dir: "{{.MCP_DIR}}"
+    env:
+      HOME_CLUSTER_MCP_CONFIG: "{{.MCP_CONFIG_FILE}}"
+      PYTHONPATH: "{{.MCP_DIR}}/src"
+    cmd: '{{.PYTHON_BIN}} -m home_cluster_mcp --config "{{.MCP_CONFIG_FILE}}"'
+    preconditions:
+      - { msg: "Missing MCP config", sh: "test -f {{.MCP_CONFIG_FILE}}" }
+
+  test:
+    desc: Run home-cluster MCP unit tests
+    dir: "{{.ROOT_DIR}}"
+    env:
+      PYTHONPATH: "{{.MCP_DIR}}/src"
+    cmd: '{{.PYTHON_BIN}} -m pytest "{{.MCP_DIR}}/tests"'
+    preconditions:
+      - { msg: "Missing pytest", sh: "{{.PYTHON_BIN}} -m pytest --version" }

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -29,6 +29,7 @@ includes:
   kubernetes:
     aliases: ["k8s"]
     taskfile: .taskfiles/Kubernetes/Taskfile.yaml
+  mcp: .taskfiles/Mcp/Taskfile.yaml
   flux: .taskfiles/Flux/Taskfile.yaml
   repository:
     aliases: ["repo"]

--- a/kubernetes/apps/default/codex-mcp-access/app/kustomization.yaml
+++ b/kubernetes/apps/default/codex-mcp-access/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml

--- a/kubernetes/apps/default/codex-mcp-access/app/rbac.yaml
+++ b/kubernetes/apps/default/codex-mcp-access/app/rbac.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: codex-mcp
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: codex-mcp-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - events
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - services
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources:
+      - pods/log
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - ingressclasses
+      - networkpolicies
+    verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list"]
+  - apiGroups: ["events.k8s.io"]
+    resources:
+      - events
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs: ["get", "list"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources:
+      - kustomizations
+    verbs: ["get", "list"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources:
+      - helmreleases
+    verbs: ["get", "list"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - buckets
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs: ["get", "list"]
+  - apiGroups: ["notification.toolkit.fluxcd.io"]
+    resources:
+      - alerts
+      - providers
+      - receivers
+    verbs: ["get", "list"]
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificates
+      - certificaterequests
+      - clusterissuers
+      - issuers
+    verbs: ["get", "list"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources:
+      - challenges
+      - orders
+    verbs: ["get", "list"]
+  - apiGroups: ["ceph.rook.io"]
+    resources:
+      - cephblockpools
+      - cephclients
+      - cephclusters
+      - cephfilesystems
+      - cephnfses
+      - cephobjectrealms
+      - cephobjectstores
+      - cephobjectstoreusers
+      - cephobjectzonegroups
+      - cephobjectzones
+      - cephrbdmirrors
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: codex-mcp-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: codex-mcp-read
+subjects:
+  - kind: ServiceAccount
+    name: codex-mcp
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: codex-mcp-exec
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: codex-mcp-exec
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: codex-mcp-exec
+subjects:
+  - kind: ServiceAccount
+    name: codex-mcp
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: codex-mcp-exec
+  namespace: media
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: codex-mcp-exec
+  namespace: media
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: codex-mcp-exec
+subjects:
+  - kind: ServiceAccount
+    name: codex-mcp
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: codex-mcp-exec
+  namespace: mymindinai
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: codex-mcp-exec
+  namespace: mymindinai
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: codex-mcp-exec
+subjects:
+  - kind: ServiceAccount
+    name: codex-mcp
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: codex-mcp-exec
+  namespace: mymindinai-dev
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: codex-mcp-exec
+  namespace: mymindinai-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: codex-mcp-exec
+subjects:
+  - kind: ServiceAccount
+    name: codex-mcp
+    namespace: default

--- a/kubernetes/apps/default/codex-mcp-access/ks.yaml
+++ b/kubernetes/apps/default/codex-mcp-access/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app codex-mcp-access
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/default/codex-mcp-access/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./namespace.yaml
   - ./homepage/ks.yaml
   - ./discord-template-notifier/ks.yaml
+  - ./codex-mcp-access/ks.yaml
   - ./pictshare/ks.yaml
   - ./open-webui/ks.yaml
   - ./limesurvey/ks.yaml

--- a/tools/home-cluster-mcp/README.md
+++ b/tools/home-cluster-mcp/README.md
@@ -1,0 +1,33 @@
+# Home Cluster MCP
+
+Local stdio MCP server for Codex-assisted troubleshooting of this GitOps
+cluster. It exposes read-focused Kubernetes and Flux tools, optional Prometheus
+queries, and tightly constrained non-interactive pod exec for app namespaces.
+
+## Install
+
+```bash
+python3 -m pip install -e "tools/home-cluster-mcp[test]"
+```
+
+## Configure
+
+1. Apply the GitOps RBAC in `kubernetes/apps/default/codex-mcp-access`.
+2. Mint a short-lived kubeconfig:
+
+   ```bash
+   task mcp:kubeconfig
+   ```
+
+3. Copy `.codex/config.toml.example` into your Codex config and adjust absolute
+   paths if needed.
+
+## Run
+
+```bash
+task mcp:run
+```
+
+The server uses stdio for MCP protocol traffic. Audit details for `pod_exec`
+are returned in the tool result and also logged on stderr so stdout remains
+valid JSON-RPC for the MCP transport.

--- a/tools/home-cluster-mcp/config.sample.yaml
+++ b/tools/home-cluster-mcp/config.sample.yaml
@@ -1,0 +1,31 @@
+kubeconfig: .private/codex-mcp/kubeconfig
+repo_root: ../..
+
+exec:
+  allowed_namespaces:
+    - default
+    - media
+    - mymindinai
+    - mymindinai-dev
+  denied_namespaces:
+    - cert-manager
+    - database
+    - flux-system
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - network
+    - observability
+    - rook-ceph
+    - storage
+
+limits:
+  log_tail_default: 100
+  log_tail_max: 200
+  event_max: 100
+  exec_timeout_seconds: 10
+  output_max_bytes: 32768
+
+prometheus:
+  url: null
+  timeout_seconds: 10

--- a/tools/home-cluster-mcp/pyproject.toml
+++ b/tools/home-cluster-mcp/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "home-cluster-mcp"
+version = "0.1.0"
+description = "Safe local MCP server for read-mostly home-cluster troubleshooting"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "httpx>=0.27",
+  "kubernetes>=29.0",
+  "mcp[cli]>=1.0",
+  "pydantic>=2.7",
+  "PyYAML>=6.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8.0",
+]
+
+[project.scripts]
+home-cluster-mcp = "home_cluster_mcp.server:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/__init__.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Safe MCP tools for the home-cluster repository."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/__main__.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/__main__.py
@@ -1,0 +1,5 @@
+from .server import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/config.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/config.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+DEFAULT_DENIED_NAMESPACES = {
+    "cert-manager",
+    "database",
+    "flux-system",
+    "kube-node-lease",
+    "kube-public",
+    "kube-system",
+    "network",
+    "observability",
+    "rook-ceph",
+    "storage",
+}
+
+DEFAULT_ALLOWED_EXEC_NAMESPACES = {
+    "default",
+    "media",
+    "mymindinai",
+    "mymindinai-dev",
+}
+
+
+@dataclass(frozen=True)
+class Limits:
+    log_tail_default: int = 100
+    log_tail_max: int = 200
+    event_max: int = 100
+    exec_timeout_seconds: int = 10
+    output_max_bytes: int = 32768
+
+    def __post_init__(self) -> None:
+        for name in (
+            "log_tail_default",
+            "log_tail_max",
+            "event_max",
+            "exec_timeout_seconds",
+            "output_max_bytes",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"limits.{name} must be a positive integer")
+        if self.log_tail_default > self.log_tail_max:
+            raise ValueError("limits.log_tail_default cannot exceed limits.log_tail_max")
+
+    def clamp_log_tail(self, tail_lines: int | None) -> int:
+        if tail_lines is None:
+            return self.log_tail_default
+        return max(1, min(int(tail_lines), self.log_tail_max))
+
+
+@dataclass(frozen=True)
+class ExecSettings:
+    allowed_namespaces: frozenset[str] = field(
+        default_factory=lambda: frozenset(DEFAULT_ALLOWED_EXEC_NAMESPACES)
+    )
+    denied_namespaces: frozenset[str] = field(
+        default_factory=lambda: frozenset(DEFAULT_DENIED_NAMESPACES)
+    )
+
+    def is_allowed_namespace(self, namespace: str) -> bool:
+        return namespace in self.allowed_namespaces and namespace not in self.denied_namespaces
+
+
+@dataclass(frozen=True)
+class PrometheusSettings:
+    url: str | None = None
+    timeout_seconds: int = 10
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.url)
+
+
+@dataclass(frozen=True)
+class Settings:
+    kubeconfig: Path
+    repo_root: Path
+    exec: ExecSettings = field(default_factory=ExecSettings)
+    limits: Limits = field(default_factory=Limits)
+    prometheus: PrometheusSettings = field(default_factory=PrometheusSettings)
+
+
+def load_settings(config_path: str | Path | None = None) -> Settings:
+    resolved_config = Path(
+        config_path
+        or os.environ.get("HOME_CLUSTER_MCP_CONFIG")
+        or "tools/home-cluster-mcp/config.sample.yaml"
+    )
+    raw = _load_yaml(resolved_config)
+    config_base = resolved_config.resolve().parent
+
+    repo_root = _resolve_path(raw.get("repo_root", "."), config_base)
+    kubeconfig = _resolve_path(raw.get("kubeconfig", ".private/codex-mcp/kubeconfig"), repo_root)
+
+    exec_raw = raw.get("exec") or {}
+    limits_raw = raw.get("limits") or {}
+    prometheus_raw = raw.get("prometheus") or {}
+
+    prometheus_url = os.environ.get("HOME_CLUSTER_MCP_PROMETHEUS_URL") or prometheus_raw.get("url")
+
+    return Settings(
+        kubeconfig=kubeconfig,
+        repo_root=repo_root,
+        exec=ExecSettings(
+            allowed_namespaces=frozenset(
+                _string_list(exec_raw.get("allowed_namespaces"), DEFAULT_ALLOWED_EXEC_NAMESPACES)
+            ),
+            denied_namespaces=frozenset(
+                _string_list(exec_raw.get("denied_namespaces"), DEFAULT_DENIED_NAMESPACES)
+            ),
+        ),
+        limits=Limits(
+            log_tail_default=int(limits_raw.get("log_tail_default", 100)),
+            log_tail_max=int(limits_raw.get("log_tail_max", 200)),
+            event_max=int(limits_raw.get("event_max", 100)),
+            exec_timeout_seconds=int(limits_raw.get("exec_timeout_seconds", 10)),
+            output_max_bytes=int(limits_raw.get("output_max_bytes", 32768)),
+        ),
+        prometheus=PrometheusSettings(
+            url=prometheus_url,
+            timeout_seconds=int(prometheus_raw.get("timeout_seconds", 10)),
+        ),
+    )
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"MCP config file not found: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError("MCP config must be a YAML mapping")
+    return data
+
+
+def _resolve_path(value: str | os.PathLike[str], base: Path) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve()
+
+
+def _string_list(value: Any, default: set[str]) -> list[str]:
+    if value is None:
+        return sorted(default)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError("expected a list of strings")
+    return value

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/exec_policy.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/exec_policy.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from urllib.parse import urlparse
+
+from .config import ExecSettings
+
+
+Risk = str
+
+DENIED_COMMANDS = {
+    "apk",
+    "apt",
+    "apt-get",
+    "ash",
+    "base64",
+    "bash",
+    "chgrp",
+    "chmod",
+    "chown",
+    "cp",
+    "dd",
+    "dnf",
+    "env",
+    "ftp",
+    "flux",
+    "helm",
+    "kill",
+    "killall",
+    "kubectl",
+    "mkfs",
+    "mount",
+    "mv",
+    "nc",
+    "ncat",
+    "npm",
+    "openssl",
+    "pip",
+    "pip3",
+    "pkill",
+    "pnpm",
+    "printenv",
+    "rm",
+    "rsync",
+    "scp",
+    "sh",
+    "socat",
+    "ssh",
+    "tar",
+    "telnet",
+    "tftp",
+    "umount",
+    "yum",
+    "zsh",
+}
+
+LOW_RISK_COMMANDS = {
+    "df",
+    "dig",
+    "getent",
+    "id",
+    "netstat",
+    "nslookup",
+    "ps",
+    "pwd",
+    "ss",
+    "whoami",
+}
+
+MEDIUM_RISK_COMMANDS = {
+    "cat",
+    "find",
+    "ls",
+}
+
+METACHARACTERS = ("|", ">", "<", "&&", "||", "`", "$(", ";")
+SECRET_PATHS = (
+    "/var/run/secrets",
+    "/run/secrets",
+    "/etc/kubernetes",
+    "/etc/rancher",
+    "/etc/shadow",
+)
+
+CURL_DENIED_FLAGS = {
+    "-d",
+    "--data",
+    "--data-raw",
+    "--data-binary",
+    "-F",
+    "--form",
+    "-T",
+    "--upload-file",
+    "-o",
+    "-O",
+    "--output",
+    "--remote-name",
+    "--proxy",
+    "--connect-to",
+}
+WGET_DENIED_FLAGS = {
+    "--post-data",
+    "--post-file",
+    "-O",
+    "--output-document",
+    "--proxy",
+}
+
+
+@dataclass(frozen=True)
+class ExecDecision:
+    allowed: bool
+    risk: Risk
+    reasons: list[str]
+    namespace: str
+    command: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def classify_exec(namespace: str, argv: list[str], settings: ExecSettings) -> ExecDecision:
+    reasons: list[str] = []
+    command = [str(item) for item in argv] if isinstance(argv, list) else []
+
+    if not command:
+        return _deny(namespace, command, "argv must be a non-empty list")
+
+    if not settings.is_allowed_namespace(namespace):
+        return _deny(namespace, command, f"namespace {namespace!r} is not exec-allowed")
+
+    binary = _basename(command[0])
+    if binary in DENIED_COMMANDS:
+        return _deny(namespace, command, f"command {binary!r} is denied")
+
+    for token in command:
+        token_str = str(token)
+        if any(marker in token_str for marker in METACHARACTERS):
+            return _deny(namespace, command, f"argument contains shell metacharacter: {token_str!r}")
+        if _contains_secret_path(token_str):
+            return _deny(namespace, command, f"argument references a protected path: {token_str!r}")
+
+    if binary in LOW_RISK_COMMANDS:
+        reasons.append(f"{binary!r} is a read-only diagnostic command")
+        return ExecDecision(True, "low", reasons, namespace, command)
+
+    if binary == "curl":
+        return _classify_curl(namespace, command)
+
+    if binary == "wget":
+        return _classify_wget(namespace, command)
+
+    if binary == "cat":
+        return _classify_cat(namespace, command)
+
+    if binary == "find":
+        return _classify_find(namespace, command)
+
+    if binary in MEDIUM_RISK_COMMANDS:
+        reasons.append(f"{binary!r} can inspect filesystem metadata and requires approval")
+        return ExecDecision(True, "medium", reasons, namespace, command)
+
+    reasons.append("unknown app command; allowed only as medium-risk approved diagnostic exec")
+    return ExecDecision(True, "medium", reasons, namespace, command)
+
+
+def _classify_curl(namespace: str, command: list[str]) -> ExecDecision:
+    for arg in command[1:]:
+        if arg in CURL_DENIED_FLAGS:
+            return _deny(namespace, command, f"curl flag {arg!r} can write or exfiltrate data")
+
+    methods = _flag_values(command, "-X", "--request")
+    for method in methods:
+        if method.upper() not in {"GET", "HEAD"}:
+            return _deny(namespace, command, f"curl method {method!r} is not read-only")
+
+    urls = _urls_in_args(command[1:])
+    external_urls = [url for url in urls if not _is_internal_url(url)]
+    if external_urls:
+        return _deny(namespace, command, f"external URL is not allowed: {external_urls[0]!r}")
+
+    if urls:
+        return ExecDecision(
+            True,
+            "low",
+            ["curl probe targets localhost, cluster DNS, or an internal service URL"],
+            namespace,
+            command,
+        )
+    return ExecDecision(True, "low", ["curl without URL, likely version/help check"], namespace, command)
+
+
+def _classify_wget(namespace: str, command: list[str]) -> ExecDecision:
+    for arg in command[1:]:
+        if arg in WGET_DENIED_FLAGS:
+            return _deny(namespace, command, f"wget flag {arg!r} can write or exfiltrate data")
+    urls = _urls_in_args(command[1:])
+    external_urls = [url for url in urls if not _is_internal_url(url)]
+    if external_urls:
+        return _deny(namespace, command, f"external URL is not allowed: {external_urls[0]!r}")
+    return ExecDecision(True, "low", ["wget probe is constrained to internal URLs"], namespace, command)
+
+
+def _classify_cat(namespace: str, command: list[str]) -> ExecDecision:
+    allowed_paths = {"/etc/resolv.conf", "/etc/hosts", "/proc/mounts", "/proc/net/route"}
+    paths = [arg for arg in command[1:] if not arg.startswith("-")]
+    if paths and all(path in allowed_paths for path in paths):
+        return ExecDecision(True, "low", ["cat is limited to known-safe diagnostic files"], namespace, command)
+    return ExecDecision(True, "medium", ["cat requires approval and protected paths are denied"], namespace, command)
+
+
+def _classify_find(namespace: str, command: list[str]) -> ExecDecision:
+    if "-exec" in command or "-delete" in command:
+        return _deny(namespace, command, "find -exec and -delete are denied")
+    if not any(arg == "-maxdepth" for arg in command):
+        return ExecDecision(
+            True,
+            "medium",
+            ["find without -maxdepth can be expensive and requires approval"],
+            namespace,
+            command,
+        )
+    return ExecDecision(True, "medium", ["find is constrained and requires approval"], namespace, command)
+
+
+def _flag_values(command: list[str], *flags: str) -> list[str]:
+    values: list[str] = []
+    for index, arg in enumerate(command):
+        if arg in flags and index + 1 < len(command):
+            values.append(command[index + 1])
+    return values
+
+
+def _urls_in_args(args: list[str]) -> list[str]:
+    return [arg for arg in args if arg.startswith(("http://", "https://"))]
+
+
+def _is_internal_url(url: str) -> bool:
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    return (
+        host in {"localhost", "127.0.0.1", "::1"}
+        or host.endswith(".svc")
+        or host.endswith(".svc.cluster.local")
+        or host.endswith(".cluster.local")
+        or "." not in host
+    )
+
+
+def _contains_secret_path(value: str) -> bool:
+    return any(path in value for path in SECRET_PATHS)
+
+
+def _basename(command: str) -> str:
+    return command.rsplit("/", 1)[-1]
+
+
+def _deny(namespace: str, command: list[str], reason: str) -> ExecDecision:
+    return ExecDecision(False, "denied", [reason], namespace, command)

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/git_hint.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/git_hint.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def resource_git_hint(
+    repo_root: Path,
+    kind: str,
+    name: str,
+    namespace: str | None = None,
+    max_matches: int = 20,
+) -> dict[str, Any]:
+    exact: list[dict[str, Any]] = []
+    fuzzy: list[str] = []
+    search_roots = [repo_root / "kubernetes" / "apps", repo_root / "kubernetes" / "flux"]
+
+    for root in search_roots:
+        if not root.exists():
+            continue
+        for path in sorted(list(root.rglob("*.yaml")) + list(root.rglob("*.yml"))):
+            if ".sops." in path.name:
+                continue
+            rel = str(path.relative_to(repo_root))
+            if name in path.parts or name in path.name:
+                fuzzy.append(rel)
+            exact.extend(_matching_documents(path, kind, name, namespace, repo_root))
+            if len(exact) >= max_matches:
+                break
+
+    return {
+        "query": {"kind": kind, "name": name, "namespace": namespace},
+        "exact_matches": exact[:max_matches],
+        "fuzzy_paths": sorted(set(fuzzy))[:max_matches],
+    }
+
+
+def _matching_documents(
+    path: Path,
+    kind: str,
+    name: str,
+    namespace: str | None,
+    repo_root: Path,
+) -> list[dict[str, Any]]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            docs = list(yaml.safe_load_all(handle))
+    except yaml.YAMLError:
+        return []
+
+    matches = []
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        metadata = doc.get("metadata") or {}
+        if doc.get("kind") != kind or metadata.get("name") != name:
+            continue
+        doc_namespace = metadata.get("namespace")
+        if namespace and doc_namespace and doc_namespace != namespace:
+            continue
+        matches.append(
+            {
+                "path": str(path.relative_to(repo_root)),
+                "apiVersion": doc.get("apiVersion"),
+                "kind": doc.get("kind"),
+                "name": metadata.get("name"),
+                "namespace": doc_namespace,
+            }
+        )
+    return matches

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/kube.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/kube.py
@@ -1,0 +1,628 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from .config import Settings
+from .exec_policy import ExecDecision, classify_exec
+from .redaction import cap_text, redact_text, redact_value
+
+
+class KubernetesClient:
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        core: Any | None = None,
+        apps: Any | None = None,
+        batch: Any | None = None,
+        custom: Any | None = None,
+        networking: Any | None = None,
+        storage: Any | None = None,
+        api_client: Any | None = None,
+        stream_func: Callable[..., Any] | None = None,
+    ) -> None:
+        self.settings = settings
+        if all(api is not None for api in (core, apps, batch, custom, networking, storage)):
+            self.core = core
+            self.apps = apps
+            self.batch = batch
+            self.custom = custom
+            self.networking = networking
+            self.storage = storage
+            self.api_client = api_client
+            self.stream_func = stream_func
+            return
+
+        from kubernetes import client, config
+        from kubernetes.stream import stream as kubernetes_stream
+
+        config.load_kube_config(config_file=str(settings.kubeconfig))
+        self.api_client = client.ApiClient()
+        self.core = client.CoreV1Api(self.api_client)
+        self.apps = client.AppsV1Api(self.api_client)
+        self.batch = client.BatchV1Api(self.api_client)
+        self.custom = client.CustomObjectsApi(self.api_client)
+        self.networking = client.NetworkingV1Api(self.api_client)
+        self.storage = client.StorageV1Api(self.api_client)
+        self.stream_func = kubernetes_stream
+
+    def cluster_overview(self) -> dict[str, Any]:
+        nodes = _items(self.core.list_node())
+        namespaces = _items(self.core.list_namespace())
+        pods = _items(self.core.list_pod_for_all_namespaces())
+        deployments = _items(self.apps.list_deployment_for_all_namespaces())
+        statefulsets = _items(self.apps.list_stateful_set_for_all_namespaces())
+        daemonsets = _items(self.apps.list_daemon_set_for_all_namespaces())
+        jobs = _items(self.batch.list_job_for_all_namespaces())
+
+        return redact_value(
+            {
+                "nodes": {
+                    "total": len(nodes),
+                    "ready": sum(1 for node in nodes if _has_condition(node, "Ready", "True")),
+                    "not_ready": [
+                        _metadata_name(node)
+                        for node in nodes
+                        if not _has_condition(node, "Ready", "True")
+                    ],
+                },
+                "namespaces": sorted(_metadata_name(ns) for ns in namespaces),
+                "pods": _pod_counts(pods),
+                "workloads": {
+                    "deployments": _ready_counts(deployments),
+                    "statefulsets": _ready_counts(statefulsets),
+                    "daemonsets": _daemonset_counts(daemonsets),
+                    "jobs": _job_counts(jobs),
+                },
+            }
+        )
+
+    def flux_status(self) -> dict[str, Any]:
+        return redact_value(
+            {
+                "kustomizations": self._flux_items(
+                    "kustomize.toolkit.fluxcd.io", "v1", "kustomizations"
+                ),
+                "helmreleases": self._flux_items("helm.toolkit.fluxcd.io", "v2", "helmreleases"),
+                "sources": {
+                    "gitrepositories": self._flux_items(
+                        "source.toolkit.fluxcd.io", "v1", "gitrepositories"
+                    ),
+                    "helmrepositories": self._flux_items(
+                        "source.toolkit.fluxcd.io", "v1", "helmrepositories"
+                    ),
+                    "ocirepositories": self._flux_items(
+                        "source.toolkit.fluxcd.io", "v1", "ocirepositories"
+                    ),
+                },
+            }
+        )
+
+    def recent_events(
+        self,
+        namespace: str | None = None,
+        involved_kind: str | None = None,
+        involved_name: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        max_items = min(limit or self.settings.limits.event_max, self.settings.limits.event_max)
+        raw_events = (
+            _items(self.core.list_namespaced_event(namespace))
+            if namespace
+            else _items(self.core.list_event_for_all_namespaces())
+        )
+        events = []
+        for event in raw_events:
+            involved = getattr(event, "involved_object", None)
+            if involved_kind and getattr(involved, "kind", None) != involved_kind:
+                continue
+            if involved_name and getattr(involved, "name", None) != involved_name:
+                continue
+            events.append(_event_summary(event))
+        events.sort(key=lambda item: item.get("time") or "", reverse=True)
+        return {"events": redact_value(events[:max_items])}
+
+    def workload_status(self, namespace: str | None = None) -> dict[str, Any]:
+        return redact_value(
+            {
+                "deployments": [
+                    _deployment_summary(item)
+                    for item in _list_by_namespace(
+                        namespace,
+                        self.apps.list_deployment_for_all_namespaces,
+                        self.apps.list_namespaced_deployment,
+                    )
+                ],
+                "statefulsets": [
+                    _statefulset_summary(item)
+                    for item in _list_by_namespace(
+                        namespace,
+                        self.apps.list_stateful_set_for_all_namespaces,
+                        self.apps.list_namespaced_stateful_set,
+                    )
+                ],
+                "daemonsets": [
+                    _daemonset_summary(item)
+                    for item in _list_by_namespace(
+                        namespace,
+                        self.apps.list_daemon_set_for_all_namespaces,
+                        self.apps.list_namespaced_daemon_set,
+                    )
+                ],
+                "jobs": [
+                    _job_summary(item)
+                    for item in _list_by_namespace(
+                        namespace,
+                        self.batch.list_job_for_all_namespaces,
+                        self.batch.list_namespaced_job,
+                    )
+                ],
+                "pods": [
+                    _pod_summary_brief(item)
+                    for item in _list_by_namespace(
+                        namespace,
+                        self.core.list_pod_for_all_namespaces,
+                        self.core.list_namespaced_pod,
+                    )
+                ],
+            }
+        )
+
+    def pod_summary(self, namespace: str, name: str) -> dict[str, Any]:
+        pod = self.core.read_namespaced_pod(name=name, namespace=namespace)
+        events = self.recent_events(
+            namespace=namespace,
+            involved_kind="Pod",
+            involved_name=name,
+            limit=20,
+        )["events"]
+        return redact_value({"pod": summarize_pod(pod), "events": events})
+
+    def pod_logs(
+        self,
+        namespace: str,
+        name: str,
+        container: str | None = None,
+        previous: bool = False,
+        tail_lines: int | None = None,
+    ) -> dict[str, Any]:
+        tail = self.settings.limits.clamp_log_tail(tail_lines)
+        logs = self.core.read_namespaced_pod_log(
+            name=name,
+            namespace=namespace,
+            container=container,
+            previous=previous,
+            tail_lines=tail,
+            timestamps=True,
+            _request_timeout=30,
+        )
+        redacted = redact_text(str(logs))
+        return {
+            "namespace": namespace,
+            "pod": name,
+            "container": container,
+            "previous": previous,
+            "tail_lines": tail,
+            "logs": cap_text(redacted, self.settings.limits.output_max_bytes),
+        }
+
+    def pod_exec_plan(self, namespace: str, argv: list[str]) -> dict[str, Any]:
+        return classify_exec(namespace, argv, self.settings.exec).to_dict()
+
+    def pod_exec(
+        self,
+        namespace: str,
+        pod: str,
+        container: str | None,
+        argv: list[str],
+        reason: str,
+    ) -> dict[str, Any]:
+        if not reason.strip():
+            raise ValueError("pod_exec requires a short reason")
+        decision = classify_exec(namespace, argv, self.settings.exec)
+        if not decision.allowed:
+            return {"decision": decision.to_dict(), "executed": False, "output": ""}
+        output = self._exec(namespace, pod, container, decision)
+        redacted = cap_text(redact_text(str(output)), self.settings.limits.output_max_bytes)
+        audit = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "namespace": namespace,
+            "pod": pod,
+            "container": container,
+            "command": decision.command,
+            "risk": decision.risk,
+            "reason": reason,
+        }
+        return {
+            "decision": decision.to_dict(),
+            "executed": True,
+            "audit": redact_value(audit),
+            "output": redacted,
+        }
+
+    def _exec(
+        self,
+        namespace: str,
+        pod: str,
+        container: str | None,
+        decision: ExecDecision,
+    ) -> str:
+        if self.stream_func is None:
+            raise RuntimeError("Kubernetes stream support is not configured")
+        return self.stream_func(
+            self.core.connect_get_namespaced_pod_exec,
+            pod,
+            namespace,
+            container=container,
+            command=decision.command,
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+            _request_timeout=self.settings.limits.exec_timeout_seconds,
+        )
+
+    def _flux_items(self, group: str, version: str, plural: str) -> list[dict[str, Any]]:
+        try:
+            result = self.custom.list_cluster_custom_object(group, version, plural)
+        except Exception as exc:  # noqa: BLE001 - surface API discovery failures as data.
+            return [{"kind": plural, "error": str(exc)}]
+        return [_custom_status_summary(item, plural) for item in result.get("items", [])]
+
+
+def summarize_pod(pod: Any) -> dict[str, Any]:
+    spec = getattr(pod, "spec", None)
+    status = getattr(pod, "status", None)
+    metadata = getattr(pod, "metadata", None)
+    return {
+        "name": getattr(metadata, "name", None),
+        "namespace": getattr(metadata, "namespace", None),
+        "node": getattr(spec, "node_name", None),
+        "phase": getattr(status, "phase", None),
+        "conditions": [
+            {
+                "type": getattr(condition, "type", None),
+                "status": getattr(condition, "status", None),
+                "reason": getattr(condition, "reason", None),
+                "message": getattr(condition, "message", None),
+            }
+            for condition in getattr(status, "conditions", None) or []
+        ],
+        "containers": [
+            _container_summary(container, _container_status(status, getattr(container, "name", "")))
+            for container in getattr(spec, "containers", None) or []
+        ],
+        "init_containers": [
+            _container_summary(container, _container_status(status, getattr(container, "name", "")))
+            for container in getattr(spec, "init_containers", None) or []
+        ],
+        "volumes": [_volume_summary(volume) for volume in getattr(spec, "volumes", None) or []],
+        "owner_refs": [
+            {"kind": getattr(ref, "kind", None), "name": getattr(ref, "name", None)}
+            for ref in getattr(metadata, "owner_references", None) or []
+        ],
+    }
+
+
+def _items(value: Any) -> list[Any]:
+    return list(getattr(value, "items", value or []))
+
+
+def _list_by_namespace(
+    namespace: str | None,
+    list_all: Callable[..., Any],
+    list_namespaced: Callable[..., Any],
+) -> list[Any]:
+    return _items(list_namespaced(namespace)) if namespace else _items(list_all())
+
+
+def _metadata_name(item: Any) -> str:
+    return str(getattr(getattr(item, "metadata", None), "name", ""))
+
+
+def _metadata_namespace(item: Any) -> str | None:
+    return getattr(getattr(item, "metadata", None), "namespace", None)
+
+
+def _has_condition(item: Any, condition_type: str, status: str) -> bool:
+    conditions = getattr(getattr(item, "status", None), "conditions", None) or []
+    return any(
+        getattr(condition, "type", None) == condition_type
+        and getattr(condition, "status", None) == status
+        for condition in conditions
+    )
+
+
+def _pod_counts(pods: list[Any]) -> dict[str, Any]:
+    phases: dict[str, int] = {}
+    restarts = 0
+    unready: list[dict[str, Any]] = []
+    for pod in pods:
+        phase = getattr(getattr(pod, "status", None), "phase", "Unknown")
+        phases[phase] = phases.get(phase, 0) + 1
+        statuses = getattr(getattr(pod, "status", None), "container_statuses", None) or []
+        restarts += sum(getattr(status, "restart_count", 0) or 0 for status in statuses)
+        if phase not in {"Running", "Succeeded"} or not _has_condition(pod, "Ready", "True"):
+            unready.append(
+                {
+                    "namespace": _metadata_namespace(pod),
+                    "name": _metadata_name(pod),
+                    "phase": phase,
+                }
+            )
+    return {"total": len(pods), "phases": phases, "total_restarts": restarts, "unready": unready}
+
+
+def _ready_counts(items: list[Any]) -> dict[str, Any]:
+    unready = []
+    for item in items:
+        status = getattr(item, "status", None)
+        spec = getattr(item, "spec", None)
+        desired = getattr(spec, "replicas", 0) or 0
+        ready = getattr(status, "ready_replicas", 0) or 0
+        if ready < desired:
+            unready.append(
+                {
+                    "namespace": _metadata_namespace(item),
+                    "name": _metadata_name(item),
+                    "ready": ready,
+                    "desired": desired,
+                }
+            )
+    return {"total": len(items), "unready": unready}
+
+
+def _daemonset_counts(items: list[Any]) -> dict[str, Any]:
+    unready = []
+    for item in items:
+        status = getattr(item, "status", None)
+        desired = getattr(status, "desired_number_scheduled", 0) or 0
+        ready = getattr(status, "number_ready", 0) or 0
+        if ready < desired:
+            unready.append(
+                {
+                    "namespace": _metadata_namespace(item),
+                    "name": _metadata_name(item),
+                    "ready": ready,
+                    "desired": desired,
+                }
+            )
+    return {"total": len(items), "unready": unready}
+
+
+def _job_counts(items: list[Any]) -> dict[str, Any]:
+    active = []
+    failed = []
+    for item in items:
+        status = getattr(item, "status", None)
+        summary = {"namespace": _metadata_namespace(item), "name": _metadata_name(item)}
+        if getattr(status, "active", 0):
+            active.append(summary)
+        if getattr(status, "failed", 0):
+            failed.append(summary | {"failed": getattr(status, "failed", 0)})
+    return {"total": len(items), "active": active, "failed": failed}
+
+
+def _deployment_summary(item: Any) -> dict[str, Any]:
+    status = getattr(item, "status", None)
+    spec = getattr(item, "spec", None)
+    return {
+        "namespace": _metadata_namespace(item),
+        "name": _metadata_name(item),
+        "ready": getattr(status, "ready_replicas", 0) or 0,
+        "desired": getattr(spec, "replicas", 0) or 0,
+        "updated": getattr(status, "updated_replicas", 0) or 0,
+        "images": _pod_template_images(item),
+    }
+
+
+def _statefulset_summary(item: Any) -> dict[str, Any]:
+    status = getattr(item, "status", None)
+    spec = getattr(item, "spec", None)
+    return {
+        "namespace": _metadata_namespace(item),
+        "name": _metadata_name(item),
+        "ready": getattr(status, "ready_replicas", 0) or 0,
+        "desired": getattr(spec, "replicas", 0) or 0,
+        "current_revision": getattr(status, "current_revision", None),
+        "update_revision": getattr(status, "update_revision", None),
+        "images": _pod_template_images(item),
+    }
+
+
+def _daemonset_summary(item: Any) -> dict[str, Any]:
+    status = getattr(item, "status", None)
+    return {
+        "namespace": _metadata_namespace(item),
+        "name": _metadata_name(item),
+        "ready": getattr(status, "number_ready", 0) or 0,
+        "desired": getattr(status, "desired_number_scheduled", 0) or 0,
+        "updated": getattr(status, "updated_number_scheduled", 0) or 0,
+        "images": _pod_template_images(item),
+    }
+
+
+def _job_summary(item: Any) -> dict[str, Any]:
+    status = getattr(item, "status", None)
+    return {
+        "namespace": _metadata_namespace(item),
+        "name": _metadata_name(item),
+        "active": getattr(status, "active", 0) or 0,
+        "succeeded": getattr(status, "succeeded", 0) or 0,
+        "failed": getattr(status, "failed", 0) or 0,
+    }
+
+
+def _pod_summary_brief(item: Any) -> dict[str, Any]:
+    status = getattr(item, "status", None)
+    statuses = getattr(status, "container_statuses", None) or []
+    return {
+        "namespace": _metadata_namespace(item),
+        "name": _metadata_name(item),
+        "phase": getattr(status, "phase", None),
+        "ready": _has_condition(item, "Ready", "True"),
+        "restarts": sum(getattr(container, "restart_count", 0) or 0 for container in statuses),
+        "node": getattr(getattr(item, "spec", None), "node_name", None),
+        "owners": [
+            {"kind": getattr(ref, "kind", None), "name": getattr(ref, "name", None)}
+            for ref in getattr(getattr(item, "metadata", None), "owner_references", None) or []
+        ],
+    }
+
+
+def _pod_template_images(item: Any) -> list[str]:
+    template = getattr(getattr(item, "spec", None), "template", None)
+    pod_spec = getattr(template, "spec", None)
+    containers = getattr(pod_spec, "containers", None) or []
+    return [getattr(container, "image", "") for container in containers]
+
+
+def _container_summary(container: Any, status: Any | None) -> dict[str, Any]:
+    state = getattr(status, "state", None) if status else None
+    last_state = getattr(status, "last_state", None) if status else None
+    return {
+        "name": getattr(container, "name", None),
+        "image": getattr(container, "image", None),
+        "ready": getattr(status, "ready", None) if status else None,
+        "restart_count": getattr(status, "restart_count", None) if status else None,
+        "state": _state_summary(state),
+        "last_state": _state_summary(last_state),
+        "ports": [
+            {
+                "name": getattr(port, "name", None),
+                "container_port": getattr(port, "container_port", None),
+                "protocol": getattr(port, "protocol", None),
+            }
+            for port in getattr(container, "ports", None) or []
+        ],
+        "env_refs": _env_refs(container),
+        "volume_mounts": [
+            {
+                "name": getattr(mount, "name", None),
+                "mount_path": getattr(mount, "mount_path", None),
+                "read_only": getattr(mount, "read_only", None),
+            }
+            for mount in getattr(container, "volume_mounts", None) or []
+        ],
+        "probes": {
+            "liveness": getattr(container, "liveness_probe", None) is not None,
+            "readiness": getattr(container, "readiness_probe", None) is not None,
+            "startup": getattr(container, "startup_probe", None) is not None,
+        },
+    }
+
+
+def _container_status(status: Any, name: str) -> Any | None:
+    if status is None:
+        return None
+    statuses = (
+        list(getattr(status, "container_statuses", None) or [])
+        + list(getattr(status, "init_container_statuses", None) or [])
+    )
+    return next((item for item in statuses if getattr(item, "name", None) == name), None)
+
+
+def _state_summary(state: Any | None) -> dict[str, Any] | None:
+    if state is None:
+        return None
+    for state_name in ("waiting", "running", "terminated"):
+        detail = getattr(state, state_name, None)
+        if detail is not None:
+            return {
+                "state": state_name,
+                "reason": getattr(detail, "reason", None),
+                "message": getattr(detail, "message", None),
+                "exit_code": getattr(detail, "exit_code", None),
+            }
+    return None
+
+
+def _env_refs(container: Any) -> dict[str, list[str]]:
+    refs = {"config_maps": [], "secrets": [], "field_refs": [], "resource_refs": []}
+    for env_from in getattr(container, "env_from", None) or []:
+        config_map_ref = getattr(env_from, "config_map_ref", None)
+        secret_ref = getattr(env_from, "secret_ref", None)
+        if config_map_ref:
+            refs["config_maps"].append(getattr(config_map_ref, "name", None))
+        if secret_ref:
+            refs["secrets"].append(getattr(secret_ref, "name", None))
+    for env in getattr(container, "env", None) or []:
+        value_from = getattr(env, "value_from", None)
+        if not value_from:
+            continue
+        if getattr(value_from, "config_map_key_ref", None):
+            refs["config_maps"].append(getattr(value_from.config_map_key_ref, "name", None))
+        if getattr(value_from, "secret_key_ref", None):
+            refs["secrets"].append(getattr(value_from.secret_key_ref, "name", None))
+        if getattr(value_from, "field_ref", None):
+            refs["field_refs"].append(getattr(env, "name", None))
+        if getattr(value_from, "resource_field_ref", None):
+            refs["resource_refs"].append(getattr(env, "name", None))
+    return {key: sorted({item for item in value if item}) for key, value in refs.items()}
+
+
+def _volume_summary(volume: Any) -> dict[str, Any]:
+    volume_type = "unknown"
+    ref_name = None
+    for attr, label in (
+        ("persistent_volume_claim", "persistentVolumeClaim"),
+        ("config_map", "configMap"),
+        ("secret", "secret"),
+        ("nfs", "nfs"),
+        ("empty_dir", "emptyDir"),
+        ("host_path", "hostPath"),
+        ("projected", "projected"),
+    ):
+        detail = getattr(volume, attr, None)
+        if detail is not None:
+            volume_type = label
+            ref_name = getattr(detail, "claim_name", None) or getattr(detail, "name", None)
+            break
+    return {"name": getattr(volume, "name", None), "type": volume_type, "ref_name": ref_name}
+
+
+def _event_summary(event: Any) -> dict[str, Any]:
+    involved = getattr(event, "involved_object", None)
+    return {
+        "time": _event_time(event),
+        "namespace": getattr(getattr(event, "metadata", None), "namespace", None),
+        "type": getattr(event, "type", None),
+        "reason": getattr(event, "reason", None),
+        "message": getattr(event, "message", None),
+        "count": getattr(event, "count", None),
+        "involved": {
+            "kind": getattr(involved, "kind", None),
+            "name": getattr(involved, "name", None),
+            "namespace": getattr(involved, "namespace", None),
+        },
+    }
+
+
+def _event_time(event: Any) -> str | None:
+    value = (
+        getattr(event, "last_timestamp", None)
+        or getattr(event, "event_time", None)
+        or getattr(getattr(event, "metadata", None), "creation_timestamp", None)
+    )
+    return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+def _custom_status_summary(item: dict[str, Any], plural: str) -> dict[str, Any]:
+    metadata = item.get("metadata", {})
+    status = item.get("status", {})
+    ready_condition = _ready_condition(status.get("conditions", []))
+    return {
+        "kind": item.get("kind") or plural,
+        "namespace": metadata.get("namespace"),
+        "name": metadata.get("name"),
+        "ready": ready_condition.get("status") == "True" if ready_condition else None,
+        "reason": ready_condition.get("reason") if ready_condition else None,
+        "message": ready_condition.get("message") if ready_condition else None,
+        "last_transition_time": ready_condition.get("lastTransitionTime") if ready_condition else None,
+    }
+
+
+def _ready_condition(conditions: list[dict[str, Any]]) -> dict[str, Any]:
+    return next((item for item in conditions if item.get("type") == "Ready"), {})

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/prometheus.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/prometheus.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .config import PrometheusSettings
+from .redaction import redact_value
+
+
+class PrometheusClient:
+    def __init__(self, settings: PrometheusSettings) -> None:
+        self.settings = settings
+
+    async def query(self, query: str, time: str | None = None) -> dict[str, Any]:
+        if not self.settings.enabled:
+            return {"enabled": False, "error": "Prometheus URL is not configured"}
+        if not query.strip():
+            raise ValueError("Prometheus query cannot be empty")
+
+        import httpx
+
+        params: dict[str, str] = {"query": query}
+        if time:
+            params["time"] = time
+
+        async with httpx.AsyncClient(timeout=self.settings.timeout_seconds) as client:
+            response = await client.get(f"{self.settings.url.rstrip('/')}/api/v1/query", params=params)
+            response.raise_for_status()
+            payload = response.json()
+        return redact_value({"enabled": True, "response": payload})

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/redaction.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/redaction.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+
+
+SECRET_PATH_PATTERNS = (
+    "/var/run/secrets",
+    "/run/secrets",
+    "/etc/kubernetes",
+    "/etc/rancher",
+)
+
+SENSITIVE_KEY_RE = re.compile(
+    r"(?i)\b(password|passwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret)\b"
+)
+ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(password|passwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret)"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+LONG_SECRETISH_RE = re.compile(r"\b[A-Za-z0-9+/=_-]{48,}\b")
+
+
+def redact_text(value: str) -> str:
+    text = value
+    for secret_path in SECRET_PATH_PATTERNS:
+        text = text.replace(secret_path, "[REDACTED_SECRET_PATH]")
+    text = ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+    text = BEARER_RE.sub("Bearer [REDACTED]", text)
+    text = LONG_SECRETISH_RE.sub("[REDACTED_LONG_VALUE]", text)
+    return text
+
+
+def redact_value(value: object) -> object:
+    if isinstance(value, str):
+        if SENSITIVE_KEY_RE.search(value):
+            return redact_text(value)
+        return redact_text(value)
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_value(item) for item in value)
+    if isinstance(value, dict):
+        redacted: dict[object, object] = {}
+        for key, item in value.items():
+            if isinstance(key, str) and SENSITIVE_KEY_RE.search(key):
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = redact_value(item)
+        return redacted
+    return value
+
+
+def cap_text(value: str, max_bytes: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    clipped = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return f"{clipped}\n[TRUNCATED_TO_{max_bytes}_BYTES]"

--- a/tools/home-cluster-mcp/src/home_cluster_mcp/server.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/server.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from .config import Settings, load_settings
+from .git_hint import resource_git_hint as find_resource_git_hint
+from .kube import KubernetesClient
+from .prometheus import PrometheusClient
+
+
+def create_server(settings: Settings | None = None) -> Any:
+    from mcp.server.fastmcp import FastMCP
+
+    resolved_settings = settings or load_settings()
+    kube = KubernetesClient(resolved_settings)
+    prometheus = PrometheusClient(resolved_settings.prometheus)
+
+    mcp = FastMCP("home-cluster", json_response=True)
+
+    @mcp.tool()
+    def cluster_overview() -> dict[str, Any]:
+        """Summarize node, namespace, pod, and workload health."""
+
+        return kube.cluster_overview()
+
+    @mcp.tool()
+    def flux_status() -> dict[str, Any]:
+        """Summarize Flux Kustomization, HelmRelease, and Source readiness."""
+
+        return kube.flux_status()
+
+    @mcp.tool()
+    def recent_events(
+        namespace: str | None = None,
+        involved_kind: str | None = None,
+        involved_name: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Return recent Kubernetes events, optionally filtered by object."""
+
+        return kube.recent_events(namespace, involved_kind, involved_name, limit)
+
+    @mcp.tool()
+    def workload_status(namespace: str | None = None) -> dict[str, Any]:
+        """Return readiness and restart summaries for common workload resources."""
+
+        return kube.workload_status(namespace)
+
+    @mcp.tool()
+    def pod_summary(namespace: str, name: str) -> dict[str, Any]:
+        """Return pod conditions, container state, refs, mounts, probes, and events."""
+
+        return kube.pod_summary(namespace, name)
+
+    @mcp.tool()
+    def pod_logs(
+        namespace: str,
+        name: str,
+        container: str | None = None,
+        previous: bool = False,
+        tail_lines: int | None = None,
+    ) -> dict[str, Any]:
+        """Return bounded, redacted pod logs."""
+
+        return kube.pod_logs(namespace, name, container, previous, tail_lines)
+
+    @mcp.tool()
+    def resource_git_hint(kind: str, name: str, namespace: str | None = None) -> dict[str, Any]:
+        """Find likely Git manifests for a live Kubernetes resource."""
+
+        return find_resource_git_hint(resolved_settings.repo_root, kind, name, namespace)
+
+    @mcp.tool()
+    async def prometheus_query(query: str, time: str | None = None) -> dict[str, Any]:
+        """Run a read-only Prometheus instant query when a Prometheus URL is configured."""
+
+        return await prometheus.query(query, time)
+
+    @mcp.tool()
+    def pod_exec_plan(namespace: str, argv: list[str]) -> dict[str, Any]:
+        """Classify a proposed non-interactive pod exec command without running it."""
+
+        return kube.pod_exec_plan(namespace, argv)
+
+    @mcp.tool()
+    def pod_exec(
+        namespace: str,
+        pod: str,
+        argv: list[str],
+        container: str | None = None,
+        reason: str = "",
+    ) -> dict[str, Any]:
+        """Run an approved, non-interactive, classified diagnostic command in a pod."""
+
+        result = kube.pod_exec(namespace, pod, container, argv, reason)
+        if result.get("executed"):
+            print(json.dumps({"pod_exec_audit": result.get("audit")}), file=sys.stderr, flush=True)
+        return result
+
+    return mcp
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the home-cluster MCP stdio server")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to the home-cluster MCP YAML config",
+    )
+    args = parser.parse_args(argv)
+    settings = load_settings(args.config)
+    server = create_server(settings)
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/home-cluster-mcp/tests/test_config.py
+++ b/tools/home-cluster-mcp/tests/test_config.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from home_cluster_mcp.config import load_settings
+
+
+def test_load_settings_resolves_paths_and_namespaces(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+kubeconfig: .private/codex-mcp/kubeconfig
+repo_root: repo
+exec:
+  allowed_namespaces: [default, media]
+  denied_namespaces: [kube-system]
+limits:
+  log_tail_default: 50
+  log_tail_max: 100
+  event_max: 25
+  exec_timeout_seconds: 5
+  output_max_bytes: 4096
+prometheus:
+  url: http://prometheus.example
+  timeout_seconds: 3
+""",
+        encoding="utf-8",
+    )
+
+    settings = load_settings(config)
+
+    assert settings.repo_root == (tmp_path / "repo").resolve()
+    assert settings.kubeconfig == (tmp_path / "repo/.private/codex-mcp/kubeconfig").resolve()
+    assert settings.exec.is_allowed_namespace("default")
+    assert not settings.exec.is_allowed_namespace("kube-system")
+    assert settings.limits.clamp_log_tail(200) == 100
+    assert settings.prometheus.enabled
+
+
+def test_invalid_log_limits_fail(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+limits:
+  log_tail_default: 300
+  log_tail_max: 100
+""",
+        encoding="utf-8",
+    )
+
+    try:
+        load_settings(config)
+    except ValueError as exc:
+        assert "log_tail_default" in str(exc)
+    else:
+        raise AssertionError("expected invalid limits to fail")

--- a/tools/home-cluster-mcp/tests/test_exec_policy.py
+++ b/tools/home-cluster-mcp/tests/test_exec_policy.py
@@ -1,0 +1,54 @@
+from home_cluster_mcp.config import ExecSettings
+from home_cluster_mcp.exec_policy import classify_exec
+
+
+SETTINGS = ExecSettings(
+    allowed_namespaces=frozenset({"default", "media"}),
+    denied_namespaces=frozenset({"kube-system", "database"}),
+)
+
+
+def test_denies_namespace_not_allowed() -> None:
+    decision = classify_exec("database", ["ps"], SETTINGS)
+
+    assert not decision.allowed
+    assert decision.risk == "denied"
+
+
+def test_denies_shell_and_env_dump() -> None:
+    assert not classify_exec("default", ["sh"], SETTINGS).allowed
+    assert not classify_exec("default", ["env"], SETTINGS).allowed
+
+
+def test_allows_low_risk_diagnostics() -> None:
+    decision = classify_exec("default", ["ps", "aux"], SETTINGS)
+
+    assert decision.allowed
+    assert decision.risk == "low"
+
+
+def test_allows_internal_curl_probe() -> None:
+    decision = classify_exec("default", ["curl", "-fsS", "http://localhost:8080/health"], SETTINGS)
+
+    assert decision.allowed
+    assert decision.risk == "low"
+
+
+def test_denies_external_curl_probe() -> None:
+    decision = classify_exec("default", ["curl", "https://example.com"], SETTINGS)
+
+    assert not decision.allowed
+
+
+def test_cat_safe_file_is_low_risk_but_secret_path_is_denied() -> None:
+    assert classify_exec("default", ["cat", "/etc/resolv.conf"], SETTINGS).risk == "low"
+    assert not classify_exec(
+        "default", ["cat", "/var/run/secrets/kubernetes.io/serviceaccount/token"], SETTINGS
+    ).allowed
+
+
+def test_unknown_app_command_is_medium_risk() -> None:
+    decision = classify_exec("media", ["sonarr", "--version"], SETTINGS)
+
+    assert decision.allowed
+    assert decision.risk == "medium"

--- a/tools/home-cluster-mcp/tests/test_kube.py
+++ b/tools/home-cluster-mcp/tests/test_kube.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from types import SimpleNamespace as NS
+
+from home_cluster_mcp.config import ExecSettings, Limits, PrometheusSettings, Settings
+from home_cluster_mcp.kube import KubernetesClient, summarize_pod
+
+
+def test_summarize_pod_omits_literal_env_values() -> None:
+    pod = NS(
+        metadata=NS(name="app-123", namespace="default", owner_references=[NS(kind="ReplicaSet", name="app")]),
+        spec=NS(
+            node_name="node-a",
+            containers=[
+                NS(
+                    name="app",
+                    image="example/app:1.0",
+                    ports=[NS(name="http", container_port=8080, protocol="TCP")],
+                    env=[
+                        NS(name="LITERAL_SECRET", value="do-not-return", value_from=None),
+                        NS(
+                            name="FROM_SECRET",
+                            value_from=NS(
+                                secret_key_ref=NS(name="app-secret"),
+                                config_map_key_ref=None,
+                                field_ref=None,
+                                resource_field_ref=None,
+                            ),
+                        ),
+                    ],
+                    env_from=[],
+                    volume_mounts=[NS(name="config", mount_path="/config", read_only=True)],
+                    liveness_probe=object(),
+                    readiness_probe=None,
+                    startup_probe=None,
+                )
+            ],
+            init_containers=[],
+            volumes=[NS(name="config", config_map=NS(name="app-config"))],
+        ),
+        status=NS(
+            phase="Running",
+            conditions=[NS(type="Ready", status="True", reason=None, message=None)],
+            container_statuses=[NS(name="app", ready=True, restart_count=0, state=None, last_state=None)],
+            init_container_statuses=[],
+        ),
+    )
+
+    summary = summarize_pod(pod)
+
+    assert "do-not-return" not in repr(summary)
+    assert summary["containers"][0]["env_refs"]["secrets"] == ["app-secret"]
+
+
+def test_pod_exec_denied_before_streaming() -> None:
+    settings = Settings(
+        kubeconfig=Path("/tmp/kubeconfig"),
+        repo_root=Path("/tmp/repo"),
+        exec=ExecSettings(allowed_namespaces=frozenset({"default"}), denied_namespaces=frozenset({"database"})),
+        limits=Limits(),
+        prometheus=PrometheusSettings(),
+    )
+
+    client = KubernetesClient(
+        settings,
+        core=object(),
+        apps=object(),
+        batch=object(),
+        custom=object(),
+        networking=object(),
+        storage=object(),
+        stream_func=lambda *args, **kwargs: "should-not-run",
+    )
+    result = client.pod_exec("database", "postgres-0", None, ["ps"], "test")
+
+    assert result["executed"] is False
+    assert result["decision"]["risk"] == "denied"

--- a/tools/home-cluster-mcp/tests/test_prometheus.py
+++ b/tools/home-cluster-mcp/tests/test_prometheus.py
@@ -1,0 +1,11 @@
+import asyncio
+
+from home_cluster_mcp.config import PrometheusSettings
+from home_cluster_mcp.prometheus import PrometheusClient
+
+
+def test_prometheus_query_disabled() -> None:
+    result = asyncio.run(PrometheusClient(PrometheusSettings()).query("up"))
+
+    assert result["enabled"] is False
+    assert "not configured" in result["error"]

--- a/tools/home-cluster-mcp/tests/test_redaction.py
+++ b/tools/home-cluster-mcp/tests/test_redaction.py
@@ -1,0 +1,24 @@
+from home_cluster_mcp.redaction import cap_text, redact_text, redact_value
+
+
+def test_redacts_secret_assignments_and_bearer_tokens() -> None:
+    text = "password=hunter2 Authorization: Bearer abcdefghijklmnopqrstuvwxyz"
+
+    redacted = redact_text(text)
+
+    assert "hunter2" not in redacted
+    assert "abcdefghijklmnopqrstuvwxyz" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redacts_sensitive_dict_values() -> None:
+    data = {"token": "abc123", "message": "ok"}
+
+    assert redact_value(data) == {"token": "[REDACTED]", "message": "ok"}
+
+
+def test_caps_text_by_bytes() -> None:
+    capped = cap_text("abcdef", 3)
+
+    assert capped.startswith("abc")
+    assert "[TRUNCATED_TO_3_BYTES]" in capped


### PR DESCRIPTION
## Summary

- Add a local stdio Python MCP server for Codex-assisted cluster troubleshooting.
- Add GitOps-managed RBAC for a short-lived `default/codex-mcp` ServiceAccount with read-only cluster visibility and app-namespace-only `pods/exec`.
- Add Taskfile helpers, Codex config example, redaction/exec policy, optional Prometheus query support, and unit tests.

## Safety posture

- No Secret or ConfigMap value reads.
- No live apply, patch, delete, restart, reconcile, suspend, resume, or port-forward tools.
- Pod exec is non-interactive, argv-only, classified by server-side policy, approval-gated in Codex config, and limited to `default`, `media`, `mymindinai`, and `mymindinai-dev`.

## Validation

- `PYTHONPATH=tools/home-cluster-mcp/src python3 -m pytest tools/home-cluster-mcp/tests` passed: 15 tests.
- `kubectl kustomize kubernetes/apps/default/codex-mcp-access/app` passed.
- `kubectl kustomize kubernetes/apps/default` passed.
- `git diff --check` passed.
- `.codex/config.toml.example` parses with Python `tomllib`.

## Notes

- `task` and `kubeconform` were not installed in the local shell, so `task kubernetes:kubeconform` was not run.
- Existing unrelated local docs/refactor work was intentionally left out of this PR.