### PR TITLE
[codex] run MCP server from repo venv

### DIFF
--- a/.codex/config.toml.example
+++ b/.codex/config.toml.example
@@ -1,13 +1,10 @@
 [mcp_servers.home-cluster]
-command = "python3"
+command = "/home/jason/repos/home-cluster/.venv/bin/home-cluster-mcp"
 args = [
-  "-m",
-  "home_cluster_mcp",
   "--config",
   "/home/jason/repos/home-cluster/tools/home-cluster-mcp/config.sample.yaml",
 ]
-cwd = "/home/jason/repos/home-cluster/tools/home-cluster-mcp"
-env = { PYTHONPATH = "/home/jason/repos/home-cluster/tools/home-cluster-mcp/src" }
+cwd = "/home/jason/repos/home-cluster"
 enabled = true
 startup_timeout_sec = 10
 tool_timeout_sec = 60

--- a/.taskfiles/Mcp/Taskfile.yaml
+++ b/.taskfiles/Mcp/Taskfile.yaml
@@ -7,12 +7,16 @@ vars:
   MCP_CONFIG_FILE: "{{.MCP_DIR}}/config.sample.yaml"
   MCP_PRIVATE_DIR: "{{.PRIVATE_DIR}}/codex-mcp"
   MCP_KUBECONFIG_FILE: "{{.MCP_PRIVATE_DIR}}/kubeconfig"
+  MCP_PYTHON_BIN: "{{.VIRTUAL_ENV}}/bin/python"
+  MCP_SERVER_BIN: "{{.VIRTUAL_ENV}}/bin/home-cluster-mcp"
 
 tasks:
 
   install:
     desc: Install the home-cluster MCP package and test extras
-    cmd: '{{.PYTHON_BIN}} -m pip install --upgrade --editable "{{.MCP_DIR}}[test]"'
+    cmds:
+      - task: :workstation:venv
+      - '"{{.MCP_PYTHON_BIN}}" -m pip install --upgrade --editable "{{.MCP_DIR}}[test]"'
     preconditions:
       - { msg: "Missing MCP package", sh: "test -f {{.MCP_DIR}}/pyproject.toml" }
 
@@ -58,19 +62,18 @@ tasks:
 
   run:
     desc: Run the home-cluster MCP stdio server locally
-    dir: "{{.MCP_DIR}}"
+    dir: "{{.ROOT_DIR}}"
     env:
       HOME_CLUSTER_MCP_CONFIG: "{{.MCP_CONFIG_FILE}}"
-      PYTHONPATH: "{{.MCP_DIR}}/src"
-    cmd: '{{.PYTHON_BIN}} -m home_cluster_mcp --config "{{.MCP_CONFIG_FILE}}"'
+    cmd: '"{{.MCP_SERVER_BIN}}" --config "{{.MCP_CONFIG_FILE}}"'
     preconditions:
       - { msg: "Missing MCP config", sh: "test -f {{.MCP_CONFIG_FILE}}" }
+      - { msg: "Missing MCP server; run task mcp:install", sh: "test -x {{.MCP_SERVER_BIN}}" }
 
   test:
     desc: Run home-cluster MCP unit tests
     dir: "{{.ROOT_DIR}}"
-    env:
-      PYTHONPATH: "{{.MCP_DIR}}/src"
-    cmd: '{{.PYTHON_BIN}} -m pytest "{{.MCP_DIR}}/tests"'
+    cmd: '"{{.MCP_PYTHON_BIN}}" -m pytest "{{.MCP_DIR}}/tests"'
     preconditions:
-      - { msg: "Missing pytest", sh: "{{.PYTHON_BIN}} -m pytest --version" }
+      - { msg: "Missing MCP package", sh: "test -f {{.MCP_DIR}}/pyproject.toml" }
+      - { msg: "Missing MCP test environment; run task mcp:install", sh: "test -x {{.MCP_PYTHON_BIN}}" }

--- a/tools/home-cluster-mcp/README.md
+++ b/tools/home-cluster-mcp/README.md
@@ -7,7 +7,7 @@ queries, and tightly constrained non-interactive pod exec for app namespaces.
 ## Install
 
 ```bash
-python3 -m pip install -e "tools/home-cluster-mcp[test]"
+task mcp:install
 ```
 
 ## Configure
@@ -26,6 +26,12 @@ python3 -m pip install -e "tools/home-cluster-mcp[test]"
 
 ```bash
 task mcp:run
+```
+
+Codex should point at the repo venv entrypoint:
+
+```toml
+command = "/home/jason/repos/home-cluster/.venv/bin/home-cluster-mcp"
 ```
 
 The server uses stdio for MCP protocol traffic. Audit details for `pod_exec`


### PR DESCRIPTION
## Summary

- Update the MCP Taskfile so `task mcp:install` creates/uses the repo `.venv` via `workstation:venv` and installs the MCP package into that environment.
- Update `task mcp:run` and `task mcp:test` to use `.venv/bin/home-cluster-mcp` and `.venv/bin/python` instead of raw `python3` plus `PYTHONPATH`.
- Update the Codex config example and MCP README to point at the repo venv entrypoint.

## Validation

- `PYTHONPATH=tools/home-cluster-mcp/src python3 -m pytest tools/home-cluster-mcp/tests` passed: 15 tests.
- Parsed `.taskfiles/Mcp/Taskfile.yaml` and `tools/home-cluster-mcp/config.sample.yaml` with Python/PyYAML.
- Parsed `.codex/config.toml.example` with Python `tomllib` and confirmed `pod_exec` remains approval-gated.
- `git diff --check` passed.

## Notes

- The local shell still does not have the `task` binary installed, so I could not run `task mcp:install` or `task mcp:test` directly.
- Existing unrelated local docs/refactor work was intentionally left out of this PR.