### PR TITLE
[codex] fix MCP Kubernetes bearer auth

### DIFF
--- a/tools/home-cluster-mcp/src/home_cluster_mcp/kube.py
+++ b/tools/home-cluster-mcp/src/home_cluster_mcp/kube.py
@@ -38,8 +38,7 @@ class KubernetesClient:
         from kubernetes import client, config
         from kubernetes.stream import stream as kubernetes_stream
 
-        config.load_kube_config(config_file=str(settings.kubeconfig))
-        self.api_client = client.ApiClient()
+        self.api_client = _api_client_from_kubeconfig(client, config, settings.kubeconfig)
         self.core = client.CoreV1Api(self.api_client)
         self.apps = client.AppsV1Api(self.api_client)
         self.batch = client.BatchV1Api(self.api_client)
@@ -304,6 +303,19 @@ def summarize_pod(pod: Any) -> dict[str, Any]:
             for ref in getattr(metadata, "owner_references", None) or []
         ],
     }
+
+
+def _api_client_from_kubeconfig(client_module: Any, config_module: Any, kubeconfig: Any) -> Any:
+    config_module.load_kube_config(config_file=str(kubeconfig))
+    configuration = client_module.Configuration.get_default_copy()
+
+    # kubernetes>=36 loads token kubeconfigs into `authorization`, while the
+    # generated API methods ask for auth settings named `BearerToken`.
+    authorization = configuration.api_key.get("authorization")
+    if authorization and "BearerToken" not in configuration.api_key:
+        configuration.api_key["BearerToken"] = authorization
+
+    return client_module.ApiClient(configuration)
 
 
 def _items(value: Any) -> list[Any]:

--- a/tools/home-cluster-mcp/tests/test_kube.py
+++ b/tools/home-cluster-mcp/tests/test_kube.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace as NS
 
 from home_cluster_mcp.config import ExecSettings, Limits, PrometheusSettings, Settings
-from home_cluster_mcp.kube import KubernetesClient, summarize_pod
+from home_cluster_mcp.kube import KubernetesClient, _api_client_from_kubeconfig, summarize_pod
 
 
 def test_summarize_pod_omits_literal_env_values() -> None:
@@ -74,3 +74,36 @@ def test_pod_exec_denied_before_streaming() -> None:
 
     assert result["executed"] is False
     assert result["decision"]["risk"] == "denied"
+
+
+def test_api_client_maps_authorization_to_bearer_token() -> None:
+    class FakeConfiguration:
+        def __init__(self) -> None:
+            self.api_key = {"authorization": "Bearer token"}
+
+        @classmethod
+        def get_default_copy(cls) -> "FakeConfiguration":
+            return cls()
+
+    class FakeClientModule:
+        Configuration = FakeConfiguration
+
+        class ApiClient:
+            def __init__(self, configuration: FakeConfiguration) -> None:
+                self.configuration = configuration
+
+    class FakeConfigModule:
+        loaded_config_file = None
+
+        @classmethod
+        def load_kube_config(cls, config_file: str) -> None:
+            cls.loaded_config_file = config_file
+
+    api_client = _api_client_from_kubeconfig(
+        FakeClientModule,
+        FakeConfigModule,
+        "/tmp/kubeconfig",
+    )
+
+    assert FakeConfigModule.loaded_config_file == "/tmp/kubeconfig"
+    assert api_client.configuration.api_key["BearerToken"] == "Bearer token"


### PR DESCRIPTION
## Summary

- Fix the MCP Kubernetes client so token kubeconfigs authenticate with the installed Kubernetes Python client.
- Map the kubeconfig-loaded `authorization` value into the `BearerToken` auth key expected by generated API methods.
- Add a regression test for the auth-key mapping.

## Why

`kubectl` successfully used the generated `codex-mcp` kubeconfig, but the Python Kubernetes client sent requests as `system:anonymous` because `kubernetes>=36` loaded the token under `authorization` while API methods request auth settings named `BearerToken`.

## Validation

- `.venv/bin/python -m pytest tools/home-cluster-mcp/tests` passed: 16 tests.
- `git diff --check` passed.
- Parsed `.taskfiles/Mcp/Taskfile.yaml` and `tools/home-cluster-mcp/config.sample.yaml` with Python/PyYAML.
- Live smoke test with `.private/codex-mcp/kubeconfig` succeeded:
  - `nodes_total=3`
  - `nodes_ready=3`
  - `pod_total=103`
- RBAC smoke checks confirmed Secret access denied and exec allowed/denied in intended namespaces using `kubectl auth can-i ... --subresource=exec`.

## Notes

- Existing unrelated local docs/refactor work was intentionally left out of this PR.