### PR TITLE
fix(mcp): make kubeconfig task portable

### DIFF
--- a/.taskfiles/Mcp/Taskfile.yaml
+++ b/.taskfiles/Mcp/Taskfile.yaml
@@ -33,8 +33,9 @@ tasks:
           echo "Current kubeconfig does not expose certificate-authority-data with --raw --minify" >&2
           exit 1
         fi
-        umask 077
-        cat > "{{.MCP_KUBECONFIG_FILE}}" <<EOF
+        TMP_FILE="$(mktemp "{{.MCP_PRIVATE_DIR}}/.kubeconfig.XXXXXX")"
+        trap 'rm -f "$TMP_FILE"' EXIT
+        cat > "$TMP_FILE" <<EOF
         apiVersion: v1
         kind: Config
         clusters:
@@ -54,7 +55,10 @@ tasks:
             namespace: default
         current-context: codex-mcp@home-cluster
         EOF
-        chmod 600 "{{.MCP_KUBECONFIG_FILE}}"
+        chmod 600 "$TMP_FILE"
+        install -m 600 "$TMP_FILE" "{{.MCP_KUBECONFIG_FILE}}"
+        rm -f "$TMP_FILE"
+        trap - EXIT
         echo "Wrote {{.MCP_KUBECONFIG_FILE}}"
     preconditions:
       - { msg: "Missing kubectl", sh: "command -v kubectl" }


### PR DESCRIPTION
## Summary
- Replaces the `umask 077` dependency in `task mcp:kubeconfig` with a portable `mktemp` + `install -m 600` flow.
- Keeps the generated Codex MCP kubeconfig permissioned as mode `600`.

Closes #1252

## Test Plan
- `task --list`
- `git diff --check`
- `task mcp:kubeconfig KUBECONFIG_FILE=/home/wadsworth/projects/github.com/jgilfoil/home-cluster/kubeconfig`
- `stat -c %a .private/codex-mcp/kubeconfig` => `600`
- `kubectl --kubeconfig .private/codex-mcp/kubeconfig auth can-i get pods -A` => `yes`
- `kubectl --kubeconfig .private/codex-mcp/kubeconfig auth can-i get secrets -A` => `no`
- `/home/wadsworth/projects/github.com/jgilfoil/home-cluster/.venv/bin/python -m pytest tools/home-cluster-mcp/tests` => `16 passed`
