### PR TITLE
feat: add durable Codex MCP kubeconfig bootstrap

### DIFF
--- a/.taskfiles/Mcp/Taskfile.yaml
+++ b/.taskfiles/Mcp/Taskfile.yaml
@@ -9,6 +9,8 @@ vars:
   MCP_KUBECONFIG_FILE: "{{.MCP_PRIVATE_DIR}}/kubeconfig"
   MCP_PYTHON_BIN: "{{.VIRTUAL_ENV}}/bin/python"
   MCP_SERVER_BIN: "{{.VIRTUAL_ENV}}/bin/home-cluster-mcp"
+  MCP_TOKEN_DURATION: 8h
+  MCP_TOKEN_SECRET_NAME: codex-mcp-token
 
 tasks:
 
@@ -26,7 +28,7 @@ tasks:
       - mkdir -p "{{.MCP_PRIVATE_DIR}}"
       - |
         set -eu
-        TOKEN="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" -n default create token codex-mcp --duration=8h)"
+        TOKEN="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" -n default create token codex-mcp --duration={{.MCP_TOKEN_DURATION}})"
         SERVER="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" config view --raw --minify -o jsonpath='{.clusters[0].cluster.server}')"
         CA_DATA="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')"
         if [ -z "$CA_DATA" ]; then
@@ -60,6 +62,51 @@ tasks:
         rm -f "$TMP_FILE"
         trap - EXIT
         echo "Wrote {{.MCP_KUBECONFIG_FILE}}"
+    preconditions:
+      - { msg: "Missing kubectl", sh: "command -v kubectl" }
+      - { msg: "Missing kubeconfig", sh: "test -f {{.KUBECONFIG_FILE}}" }
+
+  kubeconfig-durable:
+    desc: Create a durable kubeconfig from the Codex MCP service-account token Secret
+    cmds:
+      - mkdir -p "{{.MCP_PRIVATE_DIR}}"
+      - |
+        set -eu
+        TOKEN_DATA="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" -n default get secret "{{.MCP_TOKEN_SECRET_NAME}}" -o jsonpath='{.data.token}')"
+        CA_DATA="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" -n default get secret "{{.MCP_TOKEN_SECRET_NAME}}" -o jsonpath='{.data.ca\.crt}')"
+        SERVER="$(kubectl --kubeconfig "{{.KUBECONFIG_FILE}}" config view --raw --minify -o jsonpath='{.clusters[0].cluster.server}')"
+        if [ -z "$TOKEN_DATA" ] || [ -z "$CA_DATA" ]; then
+          echo "Service-account token Secret {{.MCP_TOKEN_SECRET_NAME}} is not populated yet" >&2
+          exit 1
+        fi
+        TOKEN="$(printf '%s' "$TOKEN_DATA" | base64 --decode)"
+        TMP_FILE="$(mktemp "{{.MCP_PRIVATE_DIR}}/.kubeconfig.XXXXXX")"
+        trap 'rm -f "$TMP_FILE"' EXIT
+        cat > "$TMP_FILE" <<EOF
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: home-cluster
+          cluster:
+            server: ${SERVER}
+            certificate-authority-data: ${CA_DATA}
+        users:
+        - name: codex-mcp
+          user:
+            token: ${TOKEN}
+        contexts:
+        - name: codex-mcp@home-cluster
+          context:
+            cluster: home-cluster
+            user: codex-mcp
+            namespace: default
+        current-context: codex-mcp@home-cluster
+        EOF
+        chmod 600 "$TMP_FILE"
+        install -m 600 "$TMP_FILE" "{{.MCP_KUBECONFIG_FILE}}"
+        rm -f "$TMP_FILE"
+        trap - EXIT
+        echo "Wrote durable {{.MCP_KUBECONFIG_FILE}}"
     preconditions:
       - { msg: "Missing kubectl", sh: "command -v kubectl" }
       - { msg: "Missing kubeconfig", sh: "test -f {{.KUBECONFIG_FILE}}" }

--- a/kubernetes/apps/default/codex-mcp-access/app/kustomization.yaml
+++ b/kubernetes/apps/default/codex-mcp-access/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./rbac.yaml
+  - ./token-secret.yaml

--- a/kubernetes/apps/default/codex-mcp-access/app/token-secret.yaml
+++ b/kubernetes/apps/default/codex-mcp-access/app/token-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: codex-mcp-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: codex-mcp
+type: kubernetes.io/service-account-token

--- a/tools/home-cluster-mcp/README.md
+++ b/tools/home-cluster-mcp/README.md
@@ -13,11 +13,27 @@ task mcp:install
 ## Configure
 
 1. Apply the GitOps RBAC in `kubernetes/apps/default/codex-mcp-access`.
-2. Mint a short-lived kubeconfig:
+2. Mint a kubeconfig.
+
+   Short-lived token request, useful for one-off troubleshooting:
 
    ```bash
    task mcp:kubeconfig
    ```
+
+   Durable service-account token Secret, useful for a persistent agent VM without
+   keeping an admin kubeconfig available after bootstrap:
+
+   ```bash
+   task mcp:kubeconfig-durable
+   ```
+
+   The durable task requires a bootstrap kubeconfig that can read the
+   `codex-mcp-token` Secret after Flux has reconciled it. It reads that
+   ServiceAccount token Secret once, writes the local kubeconfig to
+   `.private/codex-mcp/kubeconfig` with `0600` permissions, and does not commit
+   the generated token. After the local kubeconfig is written and tested, the
+   bootstrap/admin kubeconfig can be removed from the agent VM.
 
 3. Copy `.codex/config.toml.example` into your Codex config and adjust absolute
    paths if needed.


### PR DESCRIPTION
## Summary
- Add a durable `kubernetes.io/service-account-token` Secret for the existing `default/codex-mcp` ServiceAccount
- Add `task mcp:kubeconfig-durable` to write `.private/codex-mcp/kubeconfig` from that token Secret with 0600 permissions
- Document the short-lived vs durable MCP kubeconfig paths and the bootstrap/admin kubeconfig removal step

## Security notes
- No token value is committed; Kubernetes populates the ServiceAccount token Secret server-side
- The durable token uses the existing `codex-mcp` RBAC instead of adding permissions
- Bootstrap still needs a kubeconfig that can read the token Secret once; after the generated kubeconfig is tested, the admin kubeconfig can be removed from the agent VM

## Validation
- `PATH="$HOME/.local/bin:$PATH" task kubernetes:kubeconform`
- `git diff --cached --check`

## Follow-up
- After merge/Flux reconcile, run `task mcp:kubeconfig-durable` with a temporary bootstrap kubeconfig, verify `kubectl auth can-i get pods -A` succeeds and `kubectl auth can-i get secrets -A` remains denied, then remove the bootstrap/admin kubeconfig from the agent VM.
