### PR TITLE
docs: add Plex restore drill and rebuild safeguards

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -21,3 +21,4 @@
 - { name: "type/break",              color: "f6412d" }
 # Uncategorized
 - { name: "hold/upstream",           color: "ee0701" }
+- { name: "rebuild/review-required", color: "5319e7" }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -229,6 +229,59 @@
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<compatibility>\\+k.s)\\.?(?<build>\\d+)$",
       "matchPackagePatterns": ["k3s"]
     },
+    // pre-cutover rebuild safety gates
+    {
+      "description": ["Pre-cutover: require review for Kubernetes and platform-sensitive updates"],
+      "matchPackagePatterns": [
+        "kubernetes",
+        "k3s",
+        "talos",
+        "sidero",
+        "flux",
+        "rook.ceph",
+        "volsync",
+        "openebs",
+        "snapshot-controller",
+        "cilium",
+        "ingress-nginx",
+        "external-dns",
+        "cloudflared",
+        "cert-manager",
+        "k8s-gateway",
+        "system-upgrade-controller",
+        "prometheus-operator",
+        "kube-prometheus-stack",
+        "metrics-server",
+        "grafana"
+      ],
+      "automerge": false,
+      "ignoreTests": false,
+      "addLabels": ["rebuild/review-required"]
+    },
+    {
+      "description": ["Pre-cutover: require review for storage, network, Flux, and node-management manifests"],
+      "matchFileNames": [
+        "ansible/**",
+        "bootstrap/**",
+        "kubernetes/flux/**",
+        "kubernetes/apps/kube-system/**",
+        "kubernetes/apps/network/**",
+        "kubernetes/apps/rook-ceph/**",
+        "kubernetes/apps/storage/**",
+        "kubernetes/apps/cert-manager/**",
+        "kubernetes/apps/observability/**"
+      ],
+      "automerge": false,
+      "ignoreTests": false,
+      "addLabels": ["rebuild/review-required"]
+    },
+    {
+      "description": ["Pre-cutover: require review for GitHub Actions and validation workflow updates"],
+      "matchManagers": ["github-actions"],
+      "automerge": false,
+      "ignoreTests": false,
+      "addLabels": ["rebuild/review-required"]
+    },
     // commit message topics
     {
       "matchDatasources": ["helm"],

--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -13,7 +13,8 @@ discussion.
 2. [Project Roadmap](./project-roadmap.md)
 3. [Automation And AI](./automation-and-ai.md)
 4. [Talos And Restore Drills](./talos-and-restore-drills.md)
-5. [Open Questions](./open-questions.md)
+5. [Plex VolSync Restore Drill](./plex-volsync-restore-drill.md)
+6. [Open Questions](./open-questions.md)
 
 ## Major Goals
 

--- a/docs/refactor/automation-and-ai.md
+++ b/docs/refactor/automation-and-ai.md
@@ -30,6 +30,17 @@ Recommended during rebuild:
 - Use AI/Codex to review Renovate PRs, identify breaking changes, and generate
   follow-up patches.
 
+Current pre-cutover posture:
+
+- `.github/renovate.json5` intentionally disables automerge for Kubernetes,
+  k3s, Talos/Sidero, Flux, Rook-Ceph, VolSync, OpenEBS/storage, Cilium,
+  ingress, external-dns, cloudflared, cert-manager, GitHub Actions, and related
+  validation-sensitive infrastructure.
+- Renovate remains visible through PRs and the dependency dashboard; this is a
+  review gate, not a dependency freeze.
+- Revisit and selectively restore automerge after restore drills and cutover
+  acceptance gates are satisfied.
+
 Recommended after rebuild:
 
 - Restore selective automerge for low-risk patch/minor updates.

--- a/docs/refactor/open-questions.md
+++ b/docs/refactor/open-questions.md
@@ -46,8 +46,12 @@ Current posture:
 
 ## Workloads
 
-1. Should `open-webui-pipelines` be backed up or treated as disposable?
-2. Should LimeSurvey get VolSync coverage before the rebuild?
+1. Should `open-webui-pipelines` be backed up or treated as disposable? It has
+   a live PVC and StatefulSet, but no Git-defined backup coverage has been
+   identified.
+2. Should LimeSurvey get VolSync coverage before the rebuild? It has separate
+   uploads and MariaDB PVCs, so the backup plan needs to account for both
+   filesystem uploads and database consistency.
 3. Should `financial-planner` be removed before the rebuild or after?
 4. Should CloudNativePG manifests be removed, archived, or kept as a future
    template?

--- a/docs/refactor/plex-volsync-restore-drill.md
+++ b/docs/refactor/plex-volsync-restore-drill.md
@@ -1,0 +1,134 @@
+# Plex VolSync Restore Drill
+
+Captured: 2026-05-29
+
+This runbook verifies that Plex metadata can be restored from the existing
+VolSync/restic backup into a scratch PVC without touching the live Plex
+environment. The manual manifest lives at
+`tests/manual/plex-volsync-restore-drill.yaml`, outside `kubernetes/`, so Flux
+will not reconcile it unless a human intentionally applies it.
+
+## Scope
+
+The drill creates only:
+
+- `ReplicationDestination/media/plex-restore-drill-20260529`
+- `PersistentVolumeClaim/media/plex-restore-drill-20260529`
+- `Pod/media/plex-restore-drill-20260529-inspect`
+
+It must not create or modify a Plex `HelmRelease`, `Deployment`, `Service`,
+`Ingress`, `LoadBalancer`, or the live `PersistentVolumeClaim/media/plex`.
+
+## Guardrails
+
+- Do not replace, patch, rename, or bind the live `plex` PVC.
+- Do not create a `ReplicationSource` for the scratch PVC.
+- Do not run restic `prune`, `forget`, `unlock`, or retention-changing
+  operations.
+- Do not print Secret values, restic environment variables, kubeconfigs, or
+  SOPS content.
+- Do not list sensitive media, library, or user filenames in notes or tickets.
+- Do not start Plex against the restored data.
+- Clean up only resources created by this drill.
+
+## Apply The Drill
+
+Run this only from a workstation that already has deliberate cluster access.
+This repository change does not require live access.
+
+```bash
+kubectl apply -f tests/manual/plex-volsync-restore-drill.yaml
+```
+
+Watch the destination and scratch PVC without printing any Secret values:
+
+```bash
+kubectl -n media get replicationdestination plex-restore-drill-20260529
+kubectl -n media describe replicationdestination plex-restore-drill-20260529
+kubectl -n media get pvc plex-restore-drill-20260529
+kubectl -n media get pod plex-restore-drill-20260529-inspect
+```
+
+Wait for the restore to complete and the inspection pod to be `Running` before
+validation. If the restore fails, collect only non-secret status and event
+output.
+
+## Validate Without Starting Plex
+
+Set the Plex metadata root in the inspection pod:
+
+```bash
+export POD=plex-restore-drill-20260529-inspect
+export ROOT='/restore/Library/Application Support/Plex Media Server'
+```
+
+Check expected Plex metadata paths without dumping filenames:
+
+```bash
+kubectl -n media exec "$POD" -- sh -c '
+set -eu
+ROOT="/restore/Library/Application Support/Plex Media Server"
+test -d "$ROOT"
+test -d "$ROOT/Plug-in Support/Databases"
+test -d "$ROOT/Metadata"
+test -d "$ROOT/Media"
+test -f "$ROOT/Plug-in Support/Databases/com.plexapp.plugins.library.db"
+'
+```
+
+Count important database and metadata objects without printing names:
+
+```bash
+kubectl -n media exec "$POD" -- sh -c '
+set -eu
+ROOT="/restore/Library/Application Support/Plex Media Server"
+printf "database_files="
+find "$ROOT/Plug-in Support/Databases" -maxdepth 1 -type f -name "*.db*" | wc -l
+printf "metadata_dirs="
+find "$ROOT/Metadata" -mindepth 1 -maxdepth 2 -type d | wc -l
+printf "media_dirs="
+find "$ROOT/Media" -mindepth 1 -maxdepth 2 -type d | wc -l
+'
+```
+
+If `sqlite3` is available in the inspection image or added manually to a
+temporary debug image, run read-only database checks:
+
+```bash
+kubectl -n media exec "$POD" -- sh -c '
+set -eu
+DB="/restore/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db"
+if command -v sqlite3 >/dev/null 2>&1; then
+  sqlite3 "$DB" "PRAGMA quick_check;"
+  sqlite3 "$DB" "PRAGMA integrity_check;"
+else
+  echo "sqlite3 not available in inspection pod; skipped database check"
+fi
+'
+```
+
+Optional read-only inspection shell:
+
+```bash
+kubectl -n media exec -it plex-restore-drill-20260529-inspect -- sh
+```
+
+Inside the shell, keep inspection read-only and avoid commands that print
+library or media filenames. Prefer `test`, `du -sh`, and bounded `find ... |
+wc -l` checks.
+
+## Cleanup
+
+After recording the validation result, delete only the drill-created resources.
+Delete the inspection pod before deleting the scratch PVC so Kubernetes does not
+have to tear down a mounted volume out from under the pod:
+
+```bash
+kubectl -n media delete pod plex-restore-drill-20260529-inspect --ignore-not-found
+kubectl -n media delete replicationdestination plex-restore-drill-20260529 --ignore-not-found
+kubectl -n media delete pvc plex-restore-drill-20260529 --ignore-not-found
+kubectl -n media get pvc,pod,replicationdestination \
+  -l home-cluster.jgilfoil.dev/manual-only=true
+```
+
+Do not delete the live Plex PVC or any VolSync backup history.

--- a/docs/refactor/talos-and-restore-drills.md
+++ b/docs/refactor/talos-and-restore-drills.md
@@ -85,6 +85,11 @@ lab architecture. A useful compromise is to restore Plex metadata into an
 alternate PVC, inspect it read-only, and validate that expected database and
 metadata files are present.
 
+The concrete manual runbook is
+[Plex VolSync Restore Drill](./plex-volsync-restore-drill.md). Its companion
+manifest is intentionally stored under `tests/manual/` so Flux will not apply it
+as part of normal reconciliation.
+
 ## Synology And Backup Endpoint Notes
 
 The VM may or may not need direct Synology NFS access.

--- a/tests/manual/plex-volsync-restore-drill.yaml
+++ b/tests/manual/plex-volsync-restore-drill.yaml
@@ -1,0 +1,110 @@
+---
+# Manual-only Plex VolSync restore drill.
+#
+# This file is intentionally outside kubernetes/ so Flux will not reconcile it.
+# Apply it only by hand during a planned restore drill:
+#
+#   kubectl apply -f tests/manual/plex-volsync-restore-drill.yaml
+#
+# Guardrails:
+# - Do not change the live plex PVC.
+# - Do not create a ReplicationSource for this scratch PVC.
+# - Do not run restic prune, forget, unlock, or retention changes.
+# - Do not print Secret values or list sensitive media/library filenames.
+# - Delete only the drill-created resources named plex-restore-drill-20260529.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: plex-restore-drill-20260529
+  namespace: media
+  labels:
+    app.kubernetes.io/name: plex
+    app.kubernetes.io/part-of: manual-restore-drill
+    home-cluster.jgilfoil.dev/manual-only: "true"
+  annotations:
+    home-cluster.jgilfoil.dev/purpose: "scratch Plex metadata restore verification"
+    home-cluster.jgilfoil.dev/guardrail: "restore to alternate PVC only; never replace live plex PVC"
+spec:
+  trigger:
+    manual: restore-once
+  restic:
+    repository: plex-restic-secret
+    copyMethod: Snapshot
+    volumeSnapshotClassName: csi-ceph-blockpool
+    cacheStorageClassName: openebs-hostpath
+    cacheCapacity: 20Gi
+    storageClassName: ceph-block
+    moverSecurityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568
+    accessModes:
+      - ReadWriteOnce
+    capacity: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-restore-drill-20260529
+  namespace: media
+  labels:
+    app.kubernetes.io/name: plex
+    app.kubernetes.io/part-of: manual-restore-drill
+    home-cluster.jgilfoil.dev/manual-only: "true"
+  annotations:
+    home-cluster.jgilfoil.dev/purpose: "scratch PVC populated from plex-restore-drill-20260529"
+    home-cluster.jgilfoil.dev/guardrail: "not a live Plex claim; do not wire into HelmRelease"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  dataSourceRef:
+    kind: ReplicationDestination
+    apiGroup: volsync.backube
+    name: plex-restore-drill-20260529
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: ceph-block
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: plex-restore-drill-20260529-inspect
+  namespace: media
+  labels:
+    app.kubernetes.io/name: plex
+    app.kubernetes.io/part-of: manual-restore-drill
+    home-cluster.jgilfoil.dev/manual-only: "true"
+  annotations:
+    home-cluster.jgilfoil.dev/purpose: "read-only inspection of restored Plex metadata"
+    home-cluster.jgilfoil.dev/guardrail: "inspection only; not Plex; no Service or Ingress"
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 568
+    runAsGroup: 568
+    runAsNonRoot: true
+    fsGroup: 568
+    fsGroupChangePolicy: OnRootMismatch
+  containers:
+    - name: inspect
+      image: docker.io/alpine:3.20
+      command:
+        - /bin/sh
+        - -c
+        - sleep 604800
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - name: restored-plex
+          mountPath: /restore
+          readOnly: true
+  volumes:
+    - name: restored-plex
+      persistentVolumeClaim:
+        claimName: plex-restore-drill-20260529
+        readOnly: true


### PR DESCRIPTION
## Summary

- Add a manual-only Plex VolSync restore drill runbook and manifest under `tests/manual/` so Flux will not reconcile it automatically.
- Validate Plex restore success by restoring to a scratch PVC and inspecting expected metadata/database paths without starting a duplicate Plex instance.
- Add pre-cutover Renovate safeguards that keep PR/dashboard visibility but disable automerge for Kubernetes/platform/rebuild-sensitive updates.
- Document the reversible rebuild-safe Renovate posture and backup hardening questions for LimeSurvey and `open-webui-pipelines`.

## Safety

- No live cluster commands were run for this change.
- No SOPS files, kubeconfigs, Kubernetes Secrets, or secret values were read or modified.
- The manual restore drill does not define a Plex `HelmRelease`, `Deployment`, `StatefulSet`, `Service`, `Ingress`, `LoadBalancer`, or `ReplicationSource`.
- The drill creates only a scratch `ReplicationDestination`, scratch PVC, and read-only inspection pod when a human deliberately applies the manifest.

## Validation

- `git diff --check`
- YAML parsed with PyYAML: 3 documents, kinds `ReplicationDestination`, `PersistentVolumeClaim`, `Pod`
- Manual YAML guardrail scan confirmed no duplicate Plex workload/service/ingress or `ReplicationSource`
- `kubeconform -strict -ignore-missing-schemas -skip ReplicationDestination tests/manual/plex-volsync-restore-drill.yaml`
- `.github/renovate.json5` JavaScript/JSON5 syntax parsed with Node; `packageRules=48`

## Notes

Codex initially hit the known bubblewrap/user-namespace sandbox issue, so the implementation was retried in an isolated task worktree with Codex sandbox bypass. Hermes/Wadsworth independently reviewed and validated the diff before commit.
