### PR TITLE
fix: allow MCP pod exec stream access

### DIFF
--- a/kubernetes/apps/default/codex-mcp-access/app/rbac.yaml
+++ b/kubernetes/apps/default/codex-mcp-access/app/rbac.yaml
@@ -127,7 +127,10 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/exec
-    verbs: ["create"]
+    # Kubernetes Python client exec streams use the GET exec endpoint, while
+    # kubectl-style exec uses POST/create. Grant only the exec subresource in
+    # the approved namespaces so both clients work without broad pod mutation.
+    verbs: ["create", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -152,7 +155,10 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/exec
-    verbs: ["create"]
+    # Kubernetes Python client exec streams use the GET exec endpoint, while
+    # kubectl-style exec uses POST/create. Grant only the exec subresource in
+    # the approved namespaces so both clients work without broad pod mutation.
+    verbs: ["create", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -177,7 +183,10 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/exec
-    verbs: ["create"]
+    # Kubernetes Python client exec streams use the GET exec endpoint, while
+    # kubectl-style exec uses POST/create. Grant only the exec subresource in
+    # the approved namespaces so both clients work without broad pod mutation.
+    verbs: ["create", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -202,7 +211,10 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/exec
-    verbs: ["create"]
+    # Kubernetes Python client exec streams use the GET exec endpoint, while
+    # kubectl-style exec uses POST/create. Grant only the exec subresource in
+    # the approved namespaces so both clients work without broad pod mutation.
+    verbs: ["create", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary
- Add `get` alongside `create` for `pods/exec` in the codex-mcp exec Roles.
- Keep the grant scoped to the existing approved exec namespaces: `default`, `media`, `mymindinai`, and `mymindinai-dev`.
- Document why `get` is needed: the Kubernetes Python client exec stream uses the GET exec endpoint, while kubectl-style exec uses POST/create.

## Validation
- `kubectl kustomize kubernetes/apps/default/codex-mcp-access/app >/tmp/codex-mcp-access-rendered.yaml`
- `git diff --check`
- `task kubernetes:kubeconform`
- `task mcp:test`
