### PR TITLE
docs: capture Talos lab cluster initialization

### DIFF
--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -13,8 +13,9 @@ discussion.
 2. [Project Roadmap](./project-roadmap.md)
 3. [Automation And AI](./automation-and-ai.md)
 4. [Talos And Restore Drills](./talos-and-restore-drills.md)
-5. [Plex VolSync Restore Drill](./plex-volsync-restore-drill.md)
-6. [Open Questions](./open-questions.md)
+5. [Talos VM Cluster Initialization](./talos-vm-cluster-initialization.md)
+6. [Plex VolSync Restore Drill](./plex-volsync-restore-drill.md)
+7. [Open Questions](./open-questions.md)
 
 ## Major Goals
 
@@ -40,7 +41,9 @@ discussion.
   downtime is desirable but not at unlimited cost or complexity.
 - Full rehearsal hardware is not currently available. A Hyper-V Talos VM may be
   useful as a narrow smoke/restore lab, but should not become a parallel GitOps
-  clone of the whole homelab.
+  clone of the whole homelab. If that VM is built, use the host's dedicated
+  Hyper-V paths: `D:\Hyper-V\Virtual Machine Configurations\` for VM config and
+  `D:\Hyper-V\Virtual Hard Disks\` for VHD/VHDX storage.
 
 ## Related Docs
 

--- a/docs/refactor/automation-and-ai.md
+++ b/docs/refactor/automation-and-ai.md
@@ -93,6 +93,27 @@ K8sGPT Operator
   -> no auto-remediation
 ```
 
+## Current Agent Access Posture
+
+Current repo/agent work has moved from conceptual AI assistance to a bounded
+workstation pattern:
+
+- GitHub access is available for branch/PR work, but changes should remain
+  PR-first and human-reviewed.
+- Codex is installed for repo analysis, planning, and patch generation.
+- The `home-cluster` MCP server is available for Codex-assisted troubleshooting
+  using a dedicated `default/codex-mcp` ServiceAccount.
+- MCP kubeconfigs are generated into `.private/codex-mcp/kubeconfig` with `0600`
+  permissions by `task mcp:kubeconfig` for short-lived tokens or
+  `task mcp:kubeconfig-durable` for the durable service-account token path.
+- The MCP RBAC is intentionally read-focused and must not include Secret access.
+  Pod exec is limited to explicitly approved namespaces/subresources for bounded
+  inspection, not general live mutation.
+
+This does not change the autonomy model below: AI-generated changes still flow
+through Git/PR review first, and broad live-cluster mutation remains out of
+scope.
+
 ## Recommended Timing
 
 Before rebuild:

--- a/docs/refactor/open-questions.md
+++ b/docs/refactor/open-questions.md
@@ -21,6 +21,9 @@ Current posture:
 - A few days should be avoided if there is a practical lower-risk path.
 - No spare hardware exists today; full rehearsal should be optional, not a hard
   prerequisite.
+- If a Hyper-V Talos VM is built, use
+  `D:\Hyper-V\Virtual Machine Configurations\` for VM configuration and
+  `D:\Hyper-V\Virtual Hard Disks\` for VHD/VHDX files.
 
 ## Storage
 

--- a/docs/refactor/project-roadmap.md
+++ b/docs/refactor/project-roadmap.md
@@ -65,7 +65,10 @@ Current owner posture:
 - A few hours of downtime is worth spending some planning and setup effort to
   achieve.
 - No spare hardware is currently available. Hyper-V VMs may be considered later
-  as a narrow Talos/restore test, not as a full homelab clone.
+  as a narrow Talos/restore test, not as a full homelab clone. When using
+  Hyper-V, place VM configuration under
+  `D:\Hyper-V\Virtual Machine Configurations\` and VHD/VHDX files under
+  `D:\Hyper-V\Virtual Hard Disks\`.
 
 ## Phase 1: Pre-Rebuild Hardening
 

--- a/docs/refactor/talos-and-restore-drills.md
+++ b/docs/refactor/talos-and-restore-drills.md
@@ -26,6 +26,61 @@ the restore path and bootstrap sequence are well understood.
 A Hyper-V Talos VM can be useful as a focused spike, but it should not start as
 a full GitOps clone of the homelab.
 
+On the Hyper-V host, use the existing dedicated Hyper-V storage locations rather
+than defaulting to the user profile or `C:\ProgramData` paths:
+
+- VM configuration path: `D:\Hyper-V\Virtual Machine Configurations\`
+- VHD/VHDX path: `D:\Hyper-V\Virtual Hard Disks\`
+
+Any PowerShell runbook or generated commands should make those paths explicit,
+for example by passing `-Path "D:\Hyper-V\Virtual Machine Configurations"` to
+`New-VM` and writing the Talos OS disk under
+`D:\Hyper-V\Virtual Hard Disks\`.
+
+## Cluster Template North Star
+
+Use the current `onedr0p/cluster-template` as the north star for Talos-era
+decisions, but not as a mandate to run its full task list or adopt every default
+during the first rebuild.
+
+Template basics that matter for the VM/rebuild test:
+
+- Talos is the node OS baseline, with rendered Talos config treated as a
+  committed artifact/runbook input rather than hand-edited node state.
+- The Kubernetes API VIP, node IPs, and gateway/load-balancer IPs should be
+  explicit and non-overlapping inside the current LAN range.
+- Cilium should be the CNI, with Talos' built-in CNI and kube-proxy disabled for
+  the Talos target. Keep the current Cilium/L2 mental model unless a deliberate
+  BGP decision is made.
+- Flux, SOPS-age, Renovate, cert-manager, external-dns, cloudflared, and
+  k8s-gateway remain part of the desired operating model.
+- The template's Gateway API/Envoy path is useful strategic context, but the
+  first rebuild should not combine Talos/storage recovery with an ingress-nginx
+  to Gateway API migration unless testing proves that migration is necessary.
+- The template's current version pins are not automatically accepted. Choose the
+  Talos and Kubernetes versions deliberately after checking Cilium, Rook-Ceph,
+  VolSync, snapshot-controller, and hardware compatibility.
+- The template's storage guidance reinforces the existing project bias: if using
+  replicated storage, use dedicated disks and prove restore behavior before
+  trusting it. The VM can validate mechanics, not three-node Rook behavior.
+
+Decision points to preserve from the template when building the VM:
+
+1. Hyper-V VM configuration and VHD/VHDX paths. Use
+   `D:\Hyper-V\Virtual Machine Configurations\` and
+   `D:\Hyper-V\Virtual Hard Disks\` unless the host layout changes.
+2. VM node IP, API VIP, gateway/LB test IPs, DNS, and NTP values.
+3. Talos Image Factory schematic/extensions. Start minimal; add only extensions
+   needed for the VM test.
+4. Install disk identifier and primary NIC MAC address from Talos maintenance
+   mode, not guesses.
+5. Cilium load-balancer mode: use the current/simple L2 posture for testing;
+   only choose DSR/BGP if the LAN/router path is deliberately validated.
+6. GitOps scope: do not run a full template-style app bootstrap for the whole
+   homelab in the VM. Install only the bootstrap components needed to answer the
+   current risk question, then record what should become the real rebuild
+   runbook.
+
 Useful questions for a VM:
 
 - Can a single-node Talos cluster be brought up without excessive friction?
@@ -42,7 +97,9 @@ Questions a VM probably will not answer well:
 - Full production cutover timing.
 
 The VM should be disposable. The artifact worth keeping is the runbook and any
-repo changes needed for the future real cluster, not the VM state itself.
+repo changes needed for the future real cluster, not the VM state itself. The
+single-node initialization steps and first successful smoke-test result are
+recorded in [Talos VM Cluster Initialization](./talos-vm-cluster-initialization.md).
 
 ## GitOps Scope
 

--- a/docs/refactor/talos-vm-cluster-initialization.md
+++ b/docs/refactor/talos-vm-cluster-initialization.md
@@ -1,0 +1,146 @@
+# Talos VM Cluster Initialization
+
+Captured: 2026-06-01
+
+This runbook records the minimal initialization path for the disposable Hyper-V
+Talos VM lab. It is intentionally scoped to proving that a single-node Talos
+cluster can come up cleanly; it is not the target production bootstrap plan.
+
+## Scope And Guardrails
+
+Use this only for the disposable Talos VM lab.
+
+- Keep generated Talos configs and kubeconfigs under `.private/talos-vm-lab/`.
+- Do not commit Talos secrets, talosconfig, kubeconfig, or machine configs.
+- Do not point Flux at the full production GitOps tree from this VM during the
+  first smoke test.
+- Do not treat the default Talos CNI as the production design. The generated
+  smoke-test config used kube-flannel and kube-proxy; the target homelab design
+  still expects a deliberate Cilium decision.
+
+## Prerequisites
+
+- Talos VM is reachable on the LAN in either maintenance mode or configured mode.
+- `talosctl` is installed locally and matches the VM Talos version closely.
+- `.private/talos-vm-lab/controlplane.yaml` validates successfully.
+- `.private/talos-vm-lab/talosconfig` exists after config generation.
+
+Validate the generated control-plane config without printing secrets:
+
+```bash
+talosctl validate \
+  --config .private/talos-vm-lab/controlplane.yaml \
+  --mode metal \
+  --strict
+```
+
+Expected result:
+
+```text
+.private/talos-vm-lab/controlplane.yaml is valid for metal mode
+```
+
+## If The VM Is Still In Maintenance Mode
+
+Maintenance-mode discovery is safe and should be done before applying config:
+
+```bash
+VM_IP=192.168.1.142
+
+talosctl --nodes "$VM_IP" --endpoints "$VM_IP" version --insecure
+talosctl --nodes "$VM_IP" --endpoints "$VM_IP" get links --insecure
+talosctl --nodes "$VM_IP" --endpoints "$VM_IP" get addresses --insecure
+talosctl --nodes "$VM_IP" --endpoints "$VM_IP" get disks --insecure
+```
+
+Only apply config after confirming the VM IP, primary NIC, and install disk are
+correct for the disposable VM:
+
+```bash
+VM_IP=192.168.1.142
+
+talosctl apply-config --insecure \
+  --nodes "$VM_IP" \
+  --file .private/talos-vm-lab/controlplane.yaml
+```
+
+This installs/configures Talos on the VM disk referenced by the machine config.
+Do not run it against real cluster nodes from this lab runbook.
+
+## Bootstrap The Single-Node Control Plane
+
+Once the secure Talos API is available with the generated `talosconfig`,
+initialize etcd and the control plane:
+
+```bash
+VM_IP=192.168.1.142
+
+talosctl --talosconfig .private/talos-vm-lab/talosconfig \
+  --nodes "$VM_IP" \
+  --endpoints "$VM_IP" \
+  bootstrap
+```
+
+Then wait for Talos and Kubernetes health:
+
+```bash
+talosctl --talosconfig .private/talos-vm-lab/talosconfig \
+  --nodes "$VM_IP" \
+  --endpoints "$VM_IP" \
+  health --wait-timeout 10m
+```
+
+A small-memory VM may briefly report a memory requirement warning. If it clears
+and the remaining health checks pass, the cluster is usable for a smoke test.
+For future repeatability, size the VM comfortably above the minimum rather than
+running near the lower bound.
+
+## Export A Lab Kubeconfig
+
+Write the Kubernetes kubeconfig under `.private/`, never over the production
+repo-root kubeconfig:
+
+```bash
+VM_IP=192.168.1.142
+
+talosctl --talosconfig .private/talos-vm-lab/talosconfig \
+  --nodes "$VM_IP" \
+  --endpoints "$VM_IP" \
+  kubeconfig .private/talos-vm-lab/kubeconfig --force
+
+chmod 600 .private/talos-vm-lab/kubeconfig
+```
+
+Verify the lab cluster:
+
+```bash
+KUBECONFIG=.private/talos-vm-lab/kubeconfig kubectl get nodes -o wide
+KUBECONFIG=.private/talos-vm-lab/kubeconfig kubectl get pods -A -o wide
+```
+
+Observed successful smoke-test shape:
+
+```text
+Talos: v1.13.3
+Kubernetes: v1.36.1
+Node: talos-j1y-a90 Ready control-plane 192.168.1.142
+Core pods: coredns, kube-apiserver, kube-controller-manager, kube-scheduler,
+           kube-flannel, and kube-proxy Running
+```
+
+## Interpretation
+
+This proves that the disposable Hyper-V VM can initialize as a single-node Talos
+cluster. It does not prove the production rebuild design yet.
+
+Still unresolved for the real rebuild:
+
+- Cilium configuration with the intended kube-proxy replacement posture.
+- Rook/Ceph behavior on real multi-node hardware.
+- VolSync restore behavior against the actual backup endpoint.
+- Production ingress, DNS, Cloudflare tunnel, and LAN routing behavior.
+- Version selection for the real Talos/Kubernetes target.
+
+The next useful lab step is either a minimal Cilium install smoke test or a
+small VolSync/restic restore-path test, depending on which risk we want to retire
+first.


### PR DESCRIPTION
## Summary

- record the disposable Talos VM single-node cluster initialization runbook
- link the new runbook from the refactor docs read order and Talos drill notes
- capture current agent access posture and explicit Hyper-V storage paths already used for the lab planning

## Verification

- `talosctl validate --config .private/talos-vm-lab/controlplane.yaml --mode metal --strict`
- `talosctl --talosconfig .private/talos-vm-lab/talosconfig --nodes 192.168.1.142 --endpoints 192.168.1.142 bootstrap`
- `talosctl --talosconfig .private/talos-vm-lab/talosconfig --nodes 192.168.1.142 --endpoints 192.168.1.142 health --wait-timeout 10m`
- `KUBECONFIG=.private/talos-vm-lab/kubeconfig kubectl get nodes -o wide`
- `KUBECONFIG=.private/talos-vm-lab/kubeconfig kubectl get pods -A`
- `git diff --check HEAD~1..HEAD`

## Notes

The generated Talos material and lab kubeconfig remain under ignored `.private/` paths and are not included in this PR.
