### PR TITLE
[codex] Pin TorrentDay host alias for Prowlarr

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -33,6 +33,10 @@ spec:
     defaultPodOptions:
       annotations:
         setGateway: "true"
+      hostAliases:
+        - ip: "5.253.85.110"
+          hostnames:
+            - "www.torrentday.com"
     controllers:
       prowlarr:
         annotations:


### PR DESCRIPTION
## Summary

- Add a Prowlarr pod `hostAliases` entry for `www.torrentday.com` pointing at `5.253.85.110`.
- Keep the configured HTTPS hostname unchanged so TLS and tracker config continue to use `www.torrentday.com`.

## Why

TorrentDay currently resolves to six A records from inside the VPN-routed Prowlarr pod, but only `5.253.85.110` responds successfully from the current VPN exit. The other addresses time out before TLS completes, which can make the indexer fail depending on which DNS answer Prowlarr receives.

## Validation

- Confirmed the local diff only changes `kubernetes/apps/media/prowlarr/app/helmrelease.yaml`.
- Skipped local kubeconform per request; GitHub CI will run repository validation.