### PR TITLE
docs: reconcile v3 rebuild planning

### DIFF
--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -1,7 +1,7 @@
 # Refactor And Rebuild Planning
 
 Captured: 2026-05-12
-Updated: 2026-07-02
+Updated: 2026-07-05
 
 This directory preserves the planning context for the next major refactor/rebuild
 of the home cluster. The goal is to continue in a clean session without losing
@@ -14,8 +14,9 @@ discussion.
 2. [Project Roadmap](./project-roadmap.md)
 3. [Automation And AI](./automation-and-ai.md)
 4. [Talos And Restore Drills](./talos-and-restore-drills.md)
-5. [Plex VolSync Restore Drill](./plex-volsync-restore-drill.md)
-6. [Open Questions](./open-questions.md)
+5. [Talos Codex MCP Access Bootstrap](./talos-codex-mcp-access.md)
+6. [Plex VolSync Restore Drill](./plex-volsync-restore-drill.md)
+7. [Open Questions](./open-questions.md)
 
 ## Major Goals
 
@@ -40,10 +41,11 @@ discussion.
 - Treat downtime as a budget and tradeoff, not a binary target. Near-zero
   downtime is desirable but not at unlimited cost or complexity.
 - Full rehearsal hardware is not currently available. A Hyper-V Talos VM now
-  exists as a narrow smoke/restore lab, but should not become a parallel GitOps
-  clone of the whole homelab.
-- Keep Rook-Ceph for the first Talos rebuild unless lab work exposes a concrete
-  blocker. Replacing storage can be a later project.
+  exists as a narrow smoke/restore lab and should be retained during the rebuild,
+  but should not become a parallel GitOps clone of the whole homelab.
+- Keep Rook-Ceph for the first Talos rebuild unless real-node storage planning
+  or restore validation exposes a concrete blocker. Replacing storage can be a
+  later project.
 - Plex VolSync restore has been tested far enough to validate expected restored
   files. Do not overbuild additional Plex validation unless a new risk appears.
 - `open-webui-pipelines` is discard-for-now. LimeSurvey backup coverage is
@@ -53,15 +55,18 @@ discussion.
 
 ## Current Lab Status
 
-Read-only Talos lab verification on 2026-07-02 showed:
+The Hyper-V Talos lab should be kept for now because it may remain useful during
+the rebuild. The important validated state from 2026-07-04 is:
 
-- Single-node Hyper-V Talos lab is reachable and Kubernetes node is `Ready`.
-- Talos is `v1.13.3`; Kubernetes server is `v1.36.1`.
-- `local-path-storage` and `volsync-system` are installed and healthy.
-- Rook-Ceph is **not** installed yet: no `rook-ceph` namespace and no Rook/Ceph
-  CRDs were present.
-- No PVs/PVCs or VolSync `ReplicationSource`/`ReplicationDestination` resources
-  were present at the time of the check.
+- Single-node Hyper-V Talos lab ran Rook `v1.20.1` / Ceph `v20.2.1` with one
+  explicitly targeted loop-backed OSD.
+- `CephCluster/rook-ceph` reached `Ready` with `HEALTH_OK`.
+- `CephBlockPool/ceph-blockpool` reached `Ready` with replication size `1`.
+- RBD CSI provisioned a scratch `ceph-block` PVC.
+- A detach/reattach write-read checksum smoke test passed.
+- The result proves basic Talos + Rook-Ceph + RBD mechanics only; real-node disk
+  planning, three-node behavior, performance, and VolSync restore behavior still
+  require separate gates.
 
 ## Related Docs
 

--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -1,6 +1,7 @@
 # Refactor And Rebuild Planning
 
 Captured: 2026-05-12
+Updated: 2026-07-02
 
 This directory preserves the planning context for the next major refactor/rebuild
 of the home cluster. The goal is to continue in a clean session without losing
@@ -31,16 +32,36 @@ discussion.
 
 - Preserve the current network model during the rebuild.
 - Treat storage as the highest-risk design area.
-- Talos is likely the desired target, but should be validated with a migration
-  plan before touching real nodes.
+- Talos is the desired target for the v3 rebuild, but real-node changes still
+  require a concrete migration/cutover plan.
 - Prefer a staged rebuild over a large, multi-axis migration.
 - Avoid combining the future VLAN migration with the cluster rebuild unless
   there is no practical alternative.
 - Treat downtime as a budget and tradeoff, not a binary target. Near-zero
   downtime is desirable but not at unlimited cost or complexity.
-- Full rehearsal hardware is not currently available. A Hyper-V Talos VM may be
-  useful as a narrow smoke/restore lab, but should not become a parallel GitOps
+- Full rehearsal hardware is not currently available. A Hyper-V Talos VM now
+  exists as a narrow smoke/restore lab, but should not become a parallel GitOps
   clone of the whole homelab.
+- Keep Rook-Ceph for the first Talos rebuild unless lab work exposes a concrete
+  blocker. Replacing storage can be a later project.
+- Plex VolSync restore has been tested far enough to validate expected restored
+  files. Do not overbuild additional Plex validation unless a new risk appears.
+- `open-webui-pipelines` is discard-for-now. LimeSurvey backup coverage is
+  deferred until the last pre-cutover hardening pass.
+- Old k3s/Ansible/bootstrap scaffolding should be archived as historical
+  reference, not maintained as the v3 build path.
+
+## Current Lab Status
+
+Read-only Talos lab verification on 2026-07-02 showed:
+
+- Single-node Hyper-V Talos lab is reachable and Kubernetes node is `Ready`.
+- Talos is `v1.13.3`; Kubernetes server is `v1.36.1`.
+- `local-path-storage` and `volsync-system` are installed and healthy.
+- Rook-Ceph is **not** installed yet: no `rook-ceph` namespace and no Rook/Ceph
+  CRDs were present.
+- No PVs/PVCs or VolSync `ReplicationSource`/`ReplicationDestination` resources
+  were present at the time of the check.
 
 ## Related Docs
 

--- a/docs/refactor/current-state.md
+++ b/docs/refactor/current-state.md
@@ -1,6 +1,7 @@
 # Current State
 
 Captured: 2026-05-12
+Updated: 2026-07-02
 
 ## Hardware
 
@@ -13,6 +14,9 @@ The live hardware still matches the committed README and Ansible inventory:
 
 The cluster is currently k3s-based. The committed k3s version is
 `v1.30.1+k3s1`.
+
+A separate disposable Hyper-V Talos lab VM exists for narrow smoke/restore
+validation. It is not a full parallel homelab.
 
 ## Network Constraints
 
@@ -51,6 +55,7 @@ Keep and update if practical:
 Disposable:
 
 - `financial-planner`, which is abandoned.
+- `open-webui-pipelines`, which is discard-for-now for v3 planning.
 
 Supporting platform services are important because the cluster needs them, but
 they are not directly user-facing in the same way as media and MMIA.
@@ -96,11 +101,12 @@ backup/restore path has failed.
 
 All media apps include the VolSync template in Git. `open-webui` includes the
 basic VolSync template. `limesurvey` has Ceph-backed uploads and MariaDB PVCs
-but no VolSync coverage yet.
+but no VolSync coverage yet. LimeSurvey backup coverage is deferred until the
+last pre-cutover hardening pass if the app will remain.
 
 `open-webui-pipelines` exists live as a PVC and StatefulSet, but there is no
 explicit `pipelines` configuration in the current Open WebUI HelmRelease values.
-Decide whether it is worth backing up or can be treated as disposable.
+It is discard-for-now for v3 planning unless the owner later reclassifies it.
 
 MMIA is not purely stateless. The Discord bot deployments mount
 `mymindinai-images-nfs` at `/app/images`. The retained NFS PVs point to:
@@ -116,6 +122,18 @@ contains manifests, and there is a database doc, but:
 - The live cluster has no CNPG Cluster resources.
 - There were no pods in the `database` namespace on 2026-05-12.
 
+## Talos Lab Snapshot
+
+Read-only Talos lab verification on 2026-07-02 showed:
+
+- Single-node Hyper-V Talos lab is reachable and Kubernetes node is `Ready`.
+- Talos is `v1.13.3`; Kubernetes server is `v1.36.1`.
+- `local-path-storage` and `volsync-system` are installed and healthy.
+- Rook-Ceph is not installed yet: no `rook-ceph` namespace and no Rook/Ceph CRDs
+  were present.
+- No PVs/PVCs or VolSync `ReplicationSource`/`ReplicationDestination` resources
+  were present at the time of the check.
+
 ## Known Current Issues
 
 These were intentionally set aside for the larger roadmap conversation, but they
@@ -124,12 +142,13 @@ should not be forgotten:
 - `kube-system/cilium` HelmRelease was not ready on 2026-05-12 because chart
   `cilium@1.16.6` rejected the deprecated `containerRuntime.integration` Helm
   value.
-- LimeSurvey should probably get backup coverage if it will remain deployed.
-- `open-webui-pipelines` needs a keep-or-discard decision.
+- LimeSurvey should probably get backup coverage if it will remain deployed, but
+  this is deferred until the last pre-cutover hardening pass.
 
 ## Git/Repo Notes
 
 The active GitOps manifests live under `kubernetes/`. Older bootstrap,
-Makejinja, Ansible, and Talos scaffolding also exists. One future cleanup
-decision is whether that scaffolding remains maintained, is archived as
-historical reference, or is replaced by a new Talos-focused bootstrap path.
+Makejinja, Ansible, and Talos scaffolding also exists. For v3, old k3s/Ansible
+and Makejinja/bootstrap scaffolding should be archived as historical reference
+once Talos-focused replacement docs/runbooks are durable. It should not remain
+the maintained v3 build path.

--- a/docs/refactor/current-state.md
+++ b/docs/refactor/current-state.md
@@ -1,7 +1,7 @@
 # Current State
 
 Captured: 2026-05-12
-Updated: 2026-07-02
+Updated: 2026-07-05
 
 ## Hardware
 
@@ -15,8 +15,8 @@ The live hardware still matches the committed README and Ansible inventory:
 The cluster is currently k3s-based. The committed k3s version is
 `v1.30.1+k3s1`.
 
-A separate disposable Hyper-V Talos lab VM exists for narrow smoke/restore
-validation. It is not a full parallel homelab.
+A separate Hyper-V Talos lab VM exists for narrow smoke/restore validation and
+should be retained during the rebuild. It is not a full parallel homelab.
 
 ## Network Constraints
 
@@ -124,15 +124,20 @@ contains manifests, and there is a database doc, but:
 
 ## Talos Lab Snapshot
 
-Read-only Talos lab verification on 2026-07-02 showed:
+Rook-Ceph/RBD smoke testing on 2026-07-04 showed:
 
-- Single-node Hyper-V Talos lab is reachable and Kubernetes node is `Ready`.
-- Talos is `v1.13.3`; Kubernetes server is `v1.36.1`.
-- `local-path-storage` and `volsync-system` are installed and healthy.
-- Rook-Ceph is not installed yet: no `rook-ceph` namespace and no Rook/Ceph CRDs
-  were present.
-- No PVs/PVCs or VolSync `ReplicationSource`/`ReplicationDestination` resources
-  were present at the time of the check.
+- Single-node Hyper-V Talos lab ran Rook `v1.20.1` and Ceph `v20.2.1` /
+  Tentacle after the VM was resized to 12 GiB RAM and 4 vCPU.
+- One explicitly targeted loop-backed OSD was used; this is not representative
+  of real Odroid disk behavior.
+- `CephCluster/rook-ceph` reached `Ready` with `HEALTH_OK`.
+- `CephBlockPool/ceph-blockpool` reached `Ready` with replication size `1`.
+- RBD CSI provisioned a scratch `ceph-block` PVC.
+- A detach/reattach write-read checksum smoke test passed.
+
+This supports keeping Rook-Ceph as the working default for the first Talos
+rebuild, while real-node disk planning, VolSync restore behavior, backup
+endpoint survival, and three-node Ceph behavior remain separate gates.
 
 ## Known Current Issues
 

--- a/docs/refactor/open-questions.md
+++ b/docs/refactor/open-questions.md
@@ -1,17 +1,33 @@
 # Open Questions
 
 Captured: 2026-05-12
+Updated: 2026-07-02
 
 These are the main questions to pick up in the next planning session.
+
+## Resolved Or Current Decisions
+
+- Hyper-V Talos VM: yes, already exists and is the narrow smoke/restore lab.
+- Rook-Ceph: retain for the first Talos rebuild unless lab testing exposes a
+  concrete blocker.
+- Small restore drill: no separate small-app drill is required by default. Plex
+  VolSync restore has already validated expected restored files.
+- Plex validation: keep additional validation lightweight unless a new risk
+  appears.
+- `open-webui-pipelines`: discard-for-now.
+- LimeSurvey VolSync coverage: defer until the last pre-cutover hardening pass.
+- Old k3s/Ansible/bootstrap scaffolding: archive as historical reference; do
+  not maintain it as the v3 build path once Talos docs/runbooks replace it.
+- Gateway API/Envoy Gateway and VLAN migration remain deferred until after the
+  rebuilt cluster is stable.
 
 ## Downtime And Migration
 
 1. What downtime target should the final runbook optimize for after restore and
    bootstrap risk are better understood?
-2. Is a Hyper-V Talos VM worth the setup effort as a narrow smoke/restore lab?
-3. Is the owner willing to do a same-hardware outage if restore testing is
+2. Is the owner willing to do a same-hardware outage if restore testing is
    strong enough?
-4. What is the explicit rollback point after nodes are reformatted?
+3. What is the explicit point-of-no-return gate before nodes are reformatted?
 
 Current posture:
 
@@ -21,53 +37,49 @@ Current posture:
 - A few days should be avoided if there is a practical lower-risk path.
 - No spare hardware exists today; full rehearsal should be optional, not a hard
   prerequisite.
+- A true same-hardware rollback after formatting nodes may not exist. The
+  practical mitigation is a cutover gate with final backups, exports, restore
+  confidence, acceptance criteria, and old backup history left untouched.
 
 ## Storage
 
-1. Should Rook-Ceph be retained for the first Talos rebuild to lower migration
-   risk?
-2. If replacing Rook, what should be evaluated: Mayastor/OpenEBS, Longhorn,
-   Synology/NFS-backed dynamic provisioning, or another option?
+1. What is the current Talos-lab Rook-Ceph status, and what blocker, if any,
+   would change the current keep-Rook decision?
+2. If Rook does prove unacceptable, what should be evaluated: Mayastor/OpenEBS,
+   Longhorn, Synology/NFS-backed dynamic provisioning, or another option?
 3. Is the convenience of dynamic PVC provisioning more important than reducing
    storage overhead?
-4. Which small app should be used for the first alternate-PVC restore drill?
-5. How much Plex validation is enough before destructive work, given that a
-   full production-like Plex restore is not practical without major lab
-   architecture?
 
 Current posture:
 
-- Keeping Rook for the first Talos rebuild depends on whether Talos + Rook +
-  VolSync restore can be made boring enough.
-- If that restore path looks painful, simpler storage options should be
-  evaluated before committing to Rook again.
+- The current decision is to keep Rook for the first Talos rebuild unless a
+  concrete blocker appears.
+- Read-only Talos lab verification on 2026-07-02 showed the single-node Talos
+  lab is up with local-path storage and VolSync, but Rook-Ceph has not been
+  installed yet: no `rook-ceph` namespace and no Rook/Ceph CRDs.
+- If the Rook path looks painful, simpler storage options should be evaluated
+  before committing to Rook again.
 - Restore drills should target alternate PVCs and must avoid corrupting or
   rewriting existing backup history.
 
 ## Workloads
 
-1. Should `open-webui-pipelines` be backed up or treated as disposable? It has
-   a live PVC and StatefulSet, but no Git-defined backup coverage has been
-   identified.
-2. Should LimeSurvey get VolSync coverage before the rebuild? It has separate
+1. Should LimeSurvey get VolSync coverage before the rebuild? It has separate
    uploads and MariaDB PVCs, so the backup plan needs to account for both
    filesystem uploads and database consistency.
-3. Should `financial-planner` be removed before the rebuild or after?
-4. Should CloudNativePG manifests be removed, archived, or kept as a future
+2. Should `financial-planner` be removed before the rebuild or after?
+3. Should CloudNativePG manifests be removed, archived, or kept as a future
    template?
-5. Is MMIA dev intentionally scaled to zero, or should that be revisited?
+4. Is MMIA dev intentionally scaled to zero, or should that be revisited?
 
 ## Architecture
 
 1. Should Talos be adopted on the existing Odroid-H2 nodes?
-2. Should Ansible/k3s bootstrap files be retained as historical reference after
-   Talos migration?
-3. Should the old Makejinja/bootstrap template flow be retired?
-4. Should spegel be included in the first stable Talos build or later?
-5. Should Gateway API/Envoy Gateway be deferred until after the cluster is
-   stable?
-6. If a Talos VM is built, should it remain a manual smoke/restore lab instead
-   of being fully bootstrapped through this repo?
+2. What exact archival shape should be used for old Ansible/k3s/bootstrap
+   material after Talos replacement runbooks are durable?
+3. Should spegel be included in the first stable Talos build or later?
+4. If the Talos VM continues to be useful, when, if ever, should it move beyond
+   a manual smoke/restore lab into a GitOps-managed test environment?
 
 ## Automation
 

--- a/docs/refactor/open-questions.md
+++ b/docs/refactor/open-questions.md
@@ -1,15 +1,17 @@
 # Open Questions
 
 Captured: 2026-05-12
-Updated: 2026-07-02
+Updated: 2026-07-05
 
 These are the main questions to pick up in the next planning session.
 
 ## Resolved Or Current Decisions
 
-- Hyper-V Talos VM: yes, already exists and is the narrow smoke/restore lab.
-- Rook-Ceph: retain for the first Talos rebuild unless lab testing exposes a
-  concrete blocker.
+- Hyper-V Talos VM: yes, already exists and should be retained as the narrow
+  smoke/restore lab during the rebuild.
+- Rook-Ceph: the disposable Talos lab proved basic single-node Rook-Ceph/RBD
+  mechanics. Retain Rook-Ceph for the first Talos rebuild unless real-node disk
+  planning or restore validation exposes a concrete blocker.
 - Small restore drill: no separate small-app drill is required by default. Plex
   VolSync restore has already validated expected restored files.
 - Plex validation: keep additional validation lightweight unless a new risk
@@ -37,14 +39,16 @@ Current posture:
 - A few days should be avoided if there is a practical lower-risk path.
 - No spare hardware exists today; full rehearsal should be optional, not a hard
   prerequisite.
+- The Hyper-V Talos VM is useful enough to keep for now, but it remains a narrow
+  lab rather than a full parallel homelab clone.
 - A true same-hardware rollback after formatting nodes may not exist. The
   practical mitigation is a cutover gate with final backups, exports, restore
   confidence, acceptance criteria, and old backup history left untouched.
 
 ## Storage
 
-1. What is the current Talos-lab Rook-Ceph status, and what blocker, if any,
-   would change the current keep-Rook decision?
+1. What real-node disk planning or restore-validation blocker, if any, would
+   change the current keep-Rook decision?
 2. If Rook does prove unacceptable, what should be evaluated: Mayastor/OpenEBS,
    Longhorn, Synology/NFS-backed dynamic provisioning, or another option?
 3. Is the convenience of dynamic PVC provisioning more important than reducing
@@ -52,13 +56,13 @@ Current posture:
 
 Current posture:
 
-- The current decision is to keep Rook for the first Talos rebuild unless a
-  concrete blocker appears.
-- Read-only Talos lab verification on 2026-07-02 showed the single-node Talos
-  lab is up with local-path storage and VolSync, but Rook-Ceph has not been
-  installed yet: no `rook-ceph` namespace and no Rook/Ceph CRDs.
-- If the Rook path looks painful, simpler storage options should be evaluated
-  before committing to Rook again.
+- A disposable single-node Talos lab has proven basic Talos + Rook-Ceph + RBD
+  PVC mechanics: Rook `v1.20.1` / Ceph `v20.2.1` reached `HEALTH_OK`, RBD CSI
+  provisioned a scratch PVC, and detach/reattach checksum verification passed.
+- Rook-Ceph remains the working default for the first Talos rebuild unless
+  real-node disk planning or restore validation exposes a concrete blocker.
+- Simpler storage options should stay in reserve if real-node Rook preparation
+  or restore behavior becomes painful.
 - Restore drills should target alternate PVCs and must avoid corrupting or
   rewriting existing backup history.
 

--- a/docs/refactor/project-roadmap.md
+++ b/docs/refactor/project-roadmap.md
@@ -1,6 +1,7 @@
 # Project Roadmap
 
 Captured: 2026-05-12
+Updated: 2026-07-02
 
 ## Goals
 
@@ -26,18 +27,20 @@ This should be treated as a v3 cluster project.
 
 The current strategic bias is:
 
-- Talos is the likely future Kubernetes node OS.
+- Talos is the target Kubernetes node OS for the v3 rebuild.
 - Keep Cilium, Flux, Renovate, SOPS-age, VolSync, and the existing network
   model.
-- Keep Rook-Ceph for the first Talos rebuild if that materially lowers storage
-  migration risk, then evaluate replacing it later.
+- Keep Rook-Ceph for the first Talos rebuild unless Talos-lab testing exposes a
+  concrete blocker, then evaluate replacing it later.
 - Do not migrate to VLANs or Gateway API during the same cutover.
 - Temporarily reduce Renovate automerge while the rebuild is underway.
 - Treat downtime as a sliding tradeoff. The preferred target is a planned
   maintenance window of hours if that can be achieved with reasonable
   preparation, while avoiding plans that casually risk multiple days offline.
 - Use restore drills to reduce risk, but do not require a full parallel
-  rehearsal cluster before the migration shape is clear.
+  rehearsal cluster before the migration shape is clear. Plex VolSync restore
+  has already validated expected restored files, so further Plex validation
+  should stay lightweight unless a new risk appears.
 
 ## Phase 0: Planning And Inventory
 
@@ -51,12 +54,16 @@ Deliverables:
 - Decision on temporary hardware or VM rehearsal.
 - Restore acceptance checklist, especially for Plex and MMIA.
 
-Decision gates:
+Decision gates and current answers:
 
-- What downtime window is acceptable?
-- Can temporary hardware or VMs be used?
-- Is Rook retained for the first Talos rebuild?
-- Is Plex metadata the top restore validation target?
+- What downtime window is acceptable? A planned window measured in hours is the
+  working target if preparation makes that realistic.
+- Can temporary hardware or VMs be used? Yes: a disposable Hyper-V Talos VM is
+  already in use as a narrow lab.
+- Is Rook retained for the first Talos rebuild? Yes, unless Talos-lab testing
+  finds a concrete blocker.
+- Is Plex metadata the top restore validation target? Yes, and the Plex VolSync
+  restore drill has already validated expected restored files.
 
 Current owner posture:
 
@@ -64,8 +71,8 @@ Current owner posture:
 - A few days of downtime should be avoided if reasonably possible.
 - A few hours of downtime is worth spending some planning and setup effort to
   achieve.
-- No spare hardware is currently available. Hyper-V VMs may be considered later
-  as a narrow Talos/restore test, not as a full homelab clone.
+- No spare hardware is currently available. The Hyper-V Talos VM is the narrow
+  Talos/restore lab, not a full homelab clone.
 
 ## Phase 1: Pre-Rebuild Hardening
 
@@ -73,12 +80,16 @@ Purpose: improve recovery confidence while the current cluster still exists.
 
 Candidate work:
 
-- Prove VolSync restore with a small app first.
-- Prove Plex restore mechanics with an alternate PVC before any destructive
-  work. Do not replace the live PVC or start a duplicate production Plex
-  instance against restored state.
-- Add LimeSurvey backups if LimeSurvey will remain.
-- Decide whether `open-webui-pipelines` is preserved.
+- Do not require a separate small-app restore drill unless a new risk calls for
+  it. Plex VolSync restore has already provided the stronger validation signal.
+- Keep any additional Plex validation lightweight. Do not replace the live PVC
+  or start a duplicate production Plex instance against restored state.
+- Verify Rook-Ceph setup on the Talos lab. As of 2026-07-02, the lab had
+  Talos/Kubernetes, local-path storage, and VolSync installed, but no Rook-Ceph
+  namespace or Rook/Ceph CRDs.
+- Add LimeSurvey backups only in the final pre-cutover hardening pass if
+  LimeSurvey will remain.
+- Treat `open-webui-pipelines` as discard-for-now.
 - Put Renovate into rebuild-safe mode.
 - Fix currently broken Flux reconciliation items before cutover if they block
   clean bootstrap.
@@ -112,6 +123,9 @@ Likely alignment targets:
 - Digest-pinned images where practical.
 - bjw-s `app-template`, updated to current conventions.
 - spegel after the rebuild for registry resilience.
+- Archive old k3s/Ansible/bootstrap scaffolding as historical reference once the
+  Talos-focused runbooks/manifests are durable. Do not maintain that scaffolding
+  as the v3 build path.
 
 Not recommended during the initial cutover:
 
@@ -141,8 +155,8 @@ Main storage options:
 Current recommendation:
 
 Use the lower-risk path first unless testing proves Rook is unacceptable:
-Talos + current storage model + proven VolSync restore. Replacing Rook can be a
-second project once the cluster OS and bootstrap are modernized.
+Talos + Rook-Ceph + proven VolSync restore. Replacing Rook can be a second
+project once the cluster OS and bootstrap are modernized.
 
 Reasons:
 
@@ -161,16 +175,20 @@ Purpose: make the destructive cutover boring.
 
 Candidate work:
 
-- Generate Talos configs without applying them.
+- Keep the existing Hyper-V Talos VM as the focused lab.
+- Generate/update Talos configs without applying them to real nodes.
 - Render Flux manifests locally.
 - Validate with kubeconform and flux-local where possible.
-- Optionally test Talos in a disposable Hyper-V VM if the migration shape makes
-  that worthwhile.
-- Test VolSync restore into alternate PVCs in a sandbox namespace, the current
-  cluster, or a disposable Talos VM. The goal is to prove restore mechanics
-  without mutating live PVCs or backup retention.
+- Test Rook-Ceph setup in the disposable Talos lab before committing to the
+  first real-node cutover shape.
+- Use additional VolSync restore checks only where they answer a concrete
+  remaining risk. The goal is to prove restore mechanics without mutating live
+  PVCs or backup retention.
 - Write the exact cutover runbook.
-- Confirm rollback points and when old backups become untouchable.
+- Define the point-of-no-return gate. There may be no practical same-hardware
+  rollback after real nodes are reformatted, so the safety model is final
+  backups, exports, acceptance criteria, and untouched backup history rather
+  than assuming rollback is available.
 
 If no temporary hardware is available, this phase becomes even more important
 because the real cutover is an outage.

--- a/docs/refactor/project-roadmap.md
+++ b/docs/refactor/project-roadmap.md
@@ -1,7 +1,7 @@
 # Project Roadmap
 
 Captured: 2026-05-12
-Updated: 2026-07-02
+Updated: 2026-07-05
 
 ## Goals
 
@@ -30,8 +30,9 @@ The current strategic bias is:
 - Talos is the target Kubernetes node OS for the v3 rebuild.
 - Keep Cilium, Flux, Renovate, SOPS-age, VolSync, and the existing network
   model.
-- Keep Rook-Ceph for the first Talos rebuild unless Talos-lab testing exposes a
-  concrete blocker, then evaluate replacing it later.
+- Keep Rook-Ceph for the first Talos rebuild unless real-node disk planning or
+  restore validation exposes a concrete blocker, then evaluate replacing it
+  later.
 - Do not migrate to VLANs or Gateway API during the same cutover.
 - Temporarily reduce Renovate automerge while the rebuild is underway.
 - Treat downtime as a sliding tradeoff. The preferred target is a planned
@@ -60,8 +61,9 @@ Decision gates and current answers:
   working target if preparation makes that realistic.
 - Can temporary hardware or VMs be used? Yes: a disposable Hyper-V Talos VM is
   already in use as a narrow lab.
-- Is Rook retained for the first Talos rebuild? Yes, unless Talos-lab testing
-  finds a concrete blocker.
+- Is Rook retained for the first Talos rebuild? Yes. The 2026-07-04 disposable
+  Talos lab proved basic single-node Rook-Ceph/RBD mechanics; real-node disk
+  planning and restore validation remain separate gates.
 - Is Plex metadata the top restore validation target? Yes, and the Plex VolSync
   restore drill has already validated expected restored files.
 
@@ -72,7 +74,8 @@ Current owner posture:
 - A few hours of downtime is worth spending some planning and setup effort to
   achieve.
 - No spare hardware is currently available. The Hyper-V Talos VM is the narrow
-  Talos/restore lab, not a full homelab clone.
+  Talos/restore lab and should be retained during the rebuild, not turned into a
+  full homelab clone.
 
 ## Phase 1: Pre-Rebuild Hardening
 
@@ -84,9 +87,10 @@ Candidate work:
   it. Plex VolSync restore has already provided the stronger validation signal.
 - Keep any additional Plex validation lightweight. Do not replace the live PVC
   or start a duplicate production Plex instance against restored state.
-- Verify Rook-Ceph setup on the Talos lab. As of 2026-07-02, the lab had
-  Talos/Kubernetes, local-path storage, and VolSync installed, but no Rook-Ceph
-  namespace or Rook/Ceph CRDs.
+- Use the 2026-07-04 Talos-lab Rook-Ceph/RBD result as the baseline storage
+  mechanics check. The remaining storage gates are real-node disk planning,
+  VolSync restore behavior through the target storage path, and backup endpoint
+  survival if the old cluster-hosted S3/MinIO front door is unavailable.
 - Add LimeSurvey backups only in the final pre-cutover hardening pass if
   LimeSurvey will remain.
 - Treat `open-webui-pipelines` as discard-for-now.
@@ -158,6 +162,12 @@ Use the lower-risk path first unless testing proves Rook is unacceptable:
 Talos + Rook-Ceph + proven VolSync restore. Replacing Rook can be a second
 project once the cluster OS and bootstrap are modernized.
 
+The 2026-07-04 disposable Talos lab did not find a Rook-Ceph blocker: a
+single-node Rook `v1.20.1` / Ceph `v20.2.1` lab reached `HEALTH_OK`, provisioned
+an RBD PVC through CSI, and passed a detach/reattach write-read checksum smoke
+test. This supports keeping Rook-Ceph for the first Talos rebuild while still
+requiring real-node disk planning and VolSync restore validation.
+
 Reasons:
 
 - The most painful failure mode is data loss, not an imperfect storage backend.
@@ -175,12 +185,13 @@ Purpose: make the destructive cutover boring.
 
 Candidate work:
 
-- Keep the existing Hyper-V Talos VM as the focused lab.
+- Keep the existing Hyper-V Talos VM as the focused lab; it may come in handy
+  during the rebuild.
 - Generate/update Talos configs without applying them to real nodes.
 - Render Flux manifests locally.
 - Validate with kubeconform and flux-local where possible.
-- Test Rook-Ceph setup in the disposable Talos lab before committing to the
-  first real-node cutover shape.
+- Reuse or rebuild the successful Rook-Ceph lab only when it answers a concrete
+  remaining cutover question.
 - Use additional VolSync restore checks only where they answer a concrete
   remaining risk. The goal is to prove restore mechanics without mutating live
   PVCs or backup retention.

--- a/docs/refactor/talos-and-restore-drills.md
+++ b/docs/refactor/talos-and-restore-drills.md
@@ -1,11 +1,26 @@
 # Talos And Restore Drills
 
 Captured: 2026-05-25
+Updated: 2026-07-02
 
 This note refines the earlier rehearsal recommendation. Full spare hardware is
 not currently available, and a complete production-like rehearsal cluster would
-add a lot of setup complexity. A narrower Talos VM or restore drill may still be
-worthwhile if it answers specific migration-risk questions.
+add a lot of setup complexity. A narrower Hyper-V Talos VM now exists and should
+remain focused on specific migration-risk questions rather than becoming a
+parallel homelab.
+
+## Current Talos Lab Status
+
+Read-only verification on 2026-07-02 showed:
+
+- Single-node Hyper-V Talos lab is reachable and Kubernetes node is `Ready`.
+- Talos is `v1.13.3`; Kubernetes server is `v1.36.1`.
+- `local-path-storage` is installed with a `local-path` `StorageClass`.
+- VolSync is installed in `volsync-system`.
+- Rook-Ceph has not been installed yet: no `rook-ceph` namespace and no
+  Rook/Ceph CRDs were present.
+- No PVs/PVCs or VolSync `ReplicationSource`/`ReplicationDestination` resources
+  were present at the time of the check.
 
 ## Downtime Framing
 
@@ -23,15 +38,17 @@ the restore path and bootstrap sequence are well understood.
 
 ## Talos VM Scope
 
-A Hyper-V Talos VM can be useful as a focused spike, but it should not start as
-a full GitOps clone of the homelab.
+The Hyper-V Talos VM is useful as a focused spike, but it should not start as a
+full GitOps clone of the homelab.
 
 Useful questions for a VM:
 
 - Can a single-node Talos cluster be brought up without excessive friction?
-- Can CNI, basic storage, and VolSync/restic run correctly on Talos?
+- Can CNI, basic storage, VolSync/restic, and Rook-Ceph run correctly enough on
+  Talos to support the first rebuild path?
 - Can the VM reach the backup endpoint that VolSync uses?
-- Can a small restic backup be restored into a scratch PVC?
+- Can a small restic backup be restored into a scratch PVC if a new risk calls
+  for that check?
 
 Questions a VM probably will not answer well:
 
@@ -63,7 +80,7 @@ test environment, but that is not the first goal.
 
 The safest useful restore drill is an alternate-PVC restore:
 
-1. Pick a small VolSync-backed app first.
+1. Pick a target that answers a concrete remaining risk.
 2. Create a separate restore destination and PVC name.
 3. Point the restore at the existing restic repository credentials.
 4. Restore into the scratch PVC.
@@ -80,10 +97,14 @@ Guardrails:
 - Do not start a duplicate production Plex instance against restored Plex state.
 - Avoid running the drill during scheduled backup windows if possible.
 
-For Plex, a full production-like validation is not practical without a larger
-lab architecture. A useful compromise is to restore Plex metadata into an
-alternate PVC, inspect it read-only, and validate that expected database and
-metadata files are present.
+Plex VolSync restore has already been tested far enough to validate expected
+restored files. From here, additional Plex validation should stay lightweight
+unless a new risk appears. A full production-like validation is not practical
+without a larger lab architecture and should not be required by default.
+
+A separate small-app restore drill is no longer required as a default next step.
+Use one only if it answers a concrete remaining question that the Plex restore
+did not answer.
 
 The concrete manual runbook is
 [Plex VolSync Restore Drill](./plex-volsync-restore-drill.md). Its companion
@@ -116,11 +137,16 @@ Do not decrypt or print secret values into planning notes.
 
 ## Storage Decision Link
 
-The Rook decision should depend on restore complexity, not preference alone.
+The Rook decision should depend on restore complexity and Talos-lab friction,
+not preference alone.
 
 Current working heuristic:
 
-- If Talos + Rook + VolSync restore can be made boring enough, keep Rook for the
-  first rebuild and evaluate storage simplification later.
+- Keep Rook for the first rebuild unless Talos-lab testing exposes a concrete
+  blocker. Evaluate storage simplification later, after the cluster OS and
+  bootstrap path are modernized.
 - If restore on Talos through Rook looks painful or fragile, evaluate simpler
   options before committing to Rook again.
+
+As of 2026-07-02, the Talos lab has not yet tested Rook-Ceph: Rook/Ceph CRDs and
+the `rook-ceph` namespace were absent during read-only verification.

--- a/docs/refactor/talos-and-restore-drills.md
+++ b/docs/refactor/talos-and-restore-drills.md
@@ -1,26 +1,30 @@
 # Talos And Restore Drills
 
 Captured: 2026-05-25
-Updated: 2026-07-02
+Updated: 2026-07-05
 
 This note refines the earlier rehearsal recommendation. Full spare hardware is
 not currently available, and a complete production-like rehearsal cluster would
 add a lot of setup complexity. A narrower Hyper-V Talos VM now exists and should
-remain focused on specific migration-risk questions rather than becoming a
-parallel homelab.
+be kept during the rebuild while remaining focused on specific migration-risk
+questions rather than becoming a parallel homelab.
 
 ## Current Talos Lab Status
 
-Read-only verification on 2026-07-02 showed:
+Rook-Ceph/RBD smoke testing on 2026-07-04 showed:
 
-- Single-node Hyper-V Talos lab is reachable and Kubernetes node is `Ready`.
-- Talos is `v1.13.3`; Kubernetes server is `v1.36.1`.
-- `local-path-storage` is installed with a `local-path` `StorageClass`.
-- VolSync is installed in `volsync-system`.
-- Rook-Ceph has not been installed yet: no `rook-ceph` namespace and no
-  Rook/Ceph CRDs were present.
-- No PVs/PVCs or VolSync `ReplicationSource`/`ReplicationDestination` resources
-  were present at the time of the check.
+- Single-node Hyper-V Talos lab ran Rook `v1.20.1` and Ceph `v20.2.1` /
+  Tentacle after the VM was resized to 12 GiB RAM and 4 vCPU.
+- One explicitly targeted loop-backed OSD was used; this is not real-disk
+  parity.
+- `CephCluster/rook-ceph` reached `Ready` with `HEALTH_OK`.
+- `CephBlockPool/ceph-blockpool` reached `Ready` with replication size `1`.
+- Ceph reported one mon, one mgr, and one OSD `up`/`in` with all PGs
+  `active+clean`.
+- RBD CSI provisioned a scratch `ceph-block` PVC.
+- A writer job wrote a marker and checksum, the PVC detached, a reader job
+  reattached it, and `sha256sum -c` verified the data.
+- Scratch test namespaces were deleted after the smoke tests.
 
 ## Downtime Framing
 
@@ -38,14 +42,14 @@ the restore path and bootstrap sequence are well understood.
 
 ## Talos VM Scope
 
-The Hyper-V Talos VM is useful as a focused spike, but it should not start as a
-full GitOps clone of the homelab.
+The Hyper-V Talos VM is useful as a focused spike and should be kept for now,
+but it should not start as a full GitOps clone of the homelab.
 
 Useful questions for a VM:
 
 - Can a single-node Talos cluster be brought up without excessive friction?
-- Can CNI, basic storage, VolSync/restic, and Rook-Ceph run correctly enough on
-  Talos to support the first rebuild path?
+- Can CNI, basic storage, VolSync/restic, and Rook-Ceph be installed and
+  reinstalled cleanly enough on Talos to support the first rebuild path?
 - Can the VM reach the backup endpoint that VolSync uses?
 - Can a small restic backup be restored into a scratch PVC if a new risk calls
   for that check?
@@ -58,8 +62,98 @@ Questions a VM probably will not answer well:
 - Real ingress, DNS, Cloudflare tunnel, and LAN routing behavior.
 - Full production cutover timing.
 
-The VM should be disposable. The artifact worth keeping is the runbook and any
-repo changes needed for the future real cluster, not the VM state itself.
+The VM should remain replaceable. It is useful enough to retain during the
+rebuild, but the artifact worth preserving is the runbook and any repo changes
+needed for the future real cluster, not irreplaceable VM state.
+
+## Talos Rook-Ceph Lab Findings
+
+Captured: 2026-07-04
+
+After the Hyper-V Talos VM was resized to 12 GiB RAM and 4 vCPU, the disposable
+single-node Talos lab successfully ran a basic Rook-Ceph/RBD smoke test. The lab
+used Rook `v1.20.1`, Ceph `v20.2.1` / Tentacle, one explicitly targeted
+loop-backed OSD, the `ceph-block` StorageClass, and the RBD CSI driver.
+
+Final validated state:
+
+- `CephCluster/rook-ceph` reached `Ready` with `HEALTH_OK`.
+- `CephBlockPool/ceph-blockpool` reached `Ready` with replication size `1`.
+- Ceph reported one mon, one mgr, and one OSD `up`/`in` with all PGs
+  `active+clean`.
+- RBD CSI controller and node plugin were both ready.
+- A scratch `ceph-block` PVC was provisioned, mounted by a writer job, detached,
+  reattached by a reader job, and verified with `sha256sum -c`.
+- Scratch namespaces and workloads were deleted after the smoke tests.
+
+What this proves:
+
+- Talos can run the Rook-Ceph control plane and a minimal RBD data path in the
+  lab VM when given enough CPU/memory.
+- Rook-Ceph remains viable for the first Talos rebuild unless real-node testing
+  exposes a concrete blocker.
+- Rook `v1.20.x` with the Ceph CSI operator path can provision RBD PVCs when the
+  CSI driver chart/resources are installed.
+
+What this does not prove:
+
+- Three-node Rook-Ceph quorum, failure-domain, or recovery behavior.
+- Real Odroid disk layout, device naming, SMART/firmware behavior, or wipe
+  safety.
+- Production Ceph performance or capacity.
+- VolSync restore behavior through Rook on Talos.
+- Backup endpoint survival if the old cluster-hosted S3/MinIO front door is
+  unavailable.
+- Full GitOps bootstrap of the future cluster.
+
+Lab runbook notes to preserve:
+
+- Keep the Talos lab replaceable and use ignored `.private/` artifacts for
+  kubeconfig, Talos config, Helm values, and scratch manifests.
+- Do not use `useAllDevices` against the VM. Target only the intended lab device.
+- The loop-backed OSD target was `/dev/loop1`; it did not survive a VM reboot and
+  had to be recreated before rerunning OSD prepare. Treat this as a lab-only
+  workaround, not real-disk parity.
+- If an OSD prepare job ran before the target loop device existed, delete only
+  the completed stale prepare job after recreating the loop device so Rook can
+  rediscover the intended lab disk.
+- Ceph Tentacle rejected `osd_memory_target: "536870912"` because it is below
+  the observed minimum of `939524096` bytes. Use at least `1073741824` for the
+  lab value.
+- A 1 GiB OSD memory limit was too low in this lab and caused an OSD crash-loop
+  in Ceph config/environment parsing. The successful lab setting was roughly
+  `2Gi` memory limit and `1Gi` memory request for OSDs.
+- Rook `v1.20.x` can install the Ceph CSI operator, but RBD PVC provisioning
+  still needs the `ceph-csi-drivers` chart/resources for ServiceAccounts, RBAC,
+  `Driver` CRs, and `OperatorConfig`.
+- For a single-node tainted Talos control-plane lab, put control-plane
+  tolerations on the RBD CSI driver and on scratch smoke-test jobs. In the
+  `ceph-csi-drivers` values, per-driver tolerations belong under
+  `drivers.rbd.controllerPlugin.tolerations` and
+  `drivers.rbd.nodePlugin.tolerations`; putting them only under
+  `operatorConfig.driverSpecDefaults` did not update the generated RBD `Driver`.
+- Disable unused CSI drivers such as CephFS in this minimal RBD lab unless they
+  are part of the test objective.
+
+Before running any future RBD PVC smoke test, verify the data path first:
+
+```bash
+export KUBECONFIG="$PWD/.private/talos-vm-lab/kubeconfig"
+
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+kubectl -n rook-ceph get cephcluster,cephblockpool -o wide
+kubectl -n rook-ceph get deploy/rook-ceph.rbd.csi.ceph.com-ctrlplugin \
+  ds/rook-ceph.rbd.csi.ceph.com-nodeplugin -o wide
+```
+
+The useful smoke-test shape is:
+
+1. Create a scratch namespace and `ceph-block` PVC.
+2. Wait for the PVC to bind.
+3. Mount it in a writer job that writes a marker and checksum.
+4. Delete the writer job to force detach.
+5. Mount the same PVC in a reader job and verify the checksum.
+6. Delete the scratch namespace.
 
 ## GitOps Scope
 
@@ -142,11 +236,13 @@ not preference alone.
 
 Current working heuristic:
 
-- Keep Rook for the first rebuild unless Talos-lab testing exposes a concrete
-  blocker. Evaluate storage simplification later, after the cluster OS and
-  bootstrap path are modernized.
+- Keep Rook for the first rebuild unless real-node disk planning or restore
+  validation exposes a concrete blocker. Evaluate storage simplification later,
+  after the cluster OS and bootstrap path are modernized.
 - If restore on Talos through Rook looks painful or fragile, evaluate simpler
   options before committing to Rook again.
 
-As of 2026-07-02, the Talos lab has not yet tested Rook-Ceph: Rook/Ceph CRDs and
-the `rook-ceph` namespace were absent during read-only verification.
+As of 2026-07-04, the Talos lab has tested enough Rook-Ceph to keep it as the
+working default: single-node Rook/Ceph reached `HEALTH_OK`, RBD CSI provisioned a
+PVC, and a detach/reattach checksum test passed. This is still not a substitute
+for real-node disk planning, three-node behavior, or VolSync restore validation.

--- a/docs/refactor/talos-codex-mcp-access.md
+++ b/docs/refactor/talos-codex-mcp-access.md
@@ -1,0 +1,210 @@
+# Talos Codex MCP Access Bootstrap
+
+This runbook creates the limited Kubernetes access that a remote Codex/MCP-style
+agent can use against the disposable Talos lab cluster. It is intentionally a
+manual bootstrap step, not a Flux-managed production change.
+
+Companion manifest:
+
+```text
+tests/manual/talos-codex-mcp-access.yaml
+```
+
+## What the manifest creates
+
+- `default/codex-mcp` ServiceAccount.
+- `codex-mcp-read` ClusterRole and ClusterRoleBinding.
+- A durable ServiceAccount token Secret named `default/codex-mcp-token`.
+- Narrow `pods/exec` access in the `default` namespace only.
+
+It does **not** grant access to Kubernetes Secrets, SOPS data, node mutation,
+PVC mutation, Flux mutation, Rook mutation, or cluster-admin.
+
+The ClusterRole includes read access for common core resources plus optional CRD
+families used during the rebuild/restore investigation: Flux, cert-manager,
+Rook/Ceph, Cilium, VolSync, and VolumeSnapshot resources. RBAC can safely refer
+to API groups that are not installed yet; those rules become useful once the
+corresponding CRDs exist.
+
+## Where the Talos kubeconfig comes from
+
+There are two different config files involved:
+
+- `talosconfig`: Talos API client config, generated when the Talos machine
+  configs are generated. This talks to the Talos API on the node.
+- `kubeconfig`: Kubernetes API client config, exported from Talos **after** the
+  control plane has been bootstrapped. This is what `kubectl apply` uses.
+
+The Kubernetes kubeconfig does not come from the Talos ISO and should not be
+copied from the current k3s cluster. Generate/export it with `talosctl` from the
+Talos lab control plane.
+
+From the repo root, for the existing disposable Hyper-V lab convention:
+
+```bash
+VM_IP=192.168.1.142
+TALOSCONFIG=.private/talos-vm-lab/talosconfig
+ADMIN_KUBECONFIG=.private/talos-vm-lab/kubeconfig
+
+talosctl --talosconfig "$TALOSCONFIG" \
+  --nodes "$VM_IP" \
+  --endpoints "$VM_IP" \
+  kubeconfig "$ADMIN_KUBECONFIG" --force
+
+chmod 600 "$ADMIN_KUBECONFIG"
+KUBECONFIG="$ADMIN_KUBECONFIG" kubectl get nodes -o wide
+```
+
+If the cluster has not been bootstrapped yet, export the kubeconfig only after:
+
+```bash
+talosctl --talosconfig "$TALOSCONFIG" \
+  --nodes "$VM_IP" \
+  --endpoints "$VM_IP" \
+  bootstrap
+
+talosctl --talosconfig "$TALOSCONFIG" \
+  --nodes "$VM_IP" \
+  --endpoints "$VM_IP" \
+  health --wait-timeout 10m
+```
+
+If this is a different Talos lab, replace `VM_IP` and the local paths with the
+Talos endpoint and talosconfig path for that lab.
+
+## Apply the access manifest
+
+From the repo root:
+
+```bash
+ADMIN_KUBECONFIG=.private/talos-vm-lab/kubeconfig
+
+KUBECONFIG="$ADMIN_KUBECONFIG" \
+  kubectl apply -f tests/manual/talos-codex-mcp-access.yaml
+```
+
+Verify the ServiceAccount and RBAC boundary with the admin kubeconfig:
+
+```bash
+KUBECONFIG="$ADMIN_KUBECONFIG" kubectl -n default get sa codex-mcp
+KUBECONFIG="$ADMIN_KUBECONFIG" kubectl auth can-i get pods -A \
+  --as=system:serviceaccount:default:codex-mcp
+KUBECONFIG="$ADMIN_KUBECONFIG" kubectl auth can-i get secrets -A \
+  --as=system:serviceaccount:default:codex-mcp
+KUBECONFIG="$ADMIN_KUBECONFIG" kubectl auth can-i create pods \
+  --subresource=exec -n default \
+  --as=system:serviceaccount:default:codex-mcp
+```
+
+Expected shape:
+
+```text
+get pods -A: yes
+get secrets -A: no
+create pods/exec in default: yes
+```
+
+## Create the restricted kubeconfig for the agent VM
+
+Use the admin kubeconfig once to copy the durable ServiceAccount token into a
+local ignored kubeconfig. The command below does not print the token.
+
+```bash
+export ADMIN_KUBECONFIG=.private/talos-vm-lab/kubeconfig
+export MCP_KUBECONFIG=.private/talos-vm-lab/codex-mcp.kubeconfig
+
+mkdir -p "$(dirname "$MCP_KUBECONFIG")"
+python3 - <<'PY'
+import base64
+import json
+import os
+import pathlib
+import stat
+import subprocess
+
+admin = os.environ.get("ADMIN_KUBECONFIG", ".private/talos-vm-lab/kubeconfig")
+out = pathlib.Path(os.environ.get("MCP_KUBECONFIG", ".private/talos-vm-lab/codex-mcp.kubeconfig"))
+
+cfg_raw = subprocess.check_output([
+    "kubectl", "--kubeconfig", admin,
+    "config", "view", "--raw", "--minify", "-o", "json",
+], text=True)
+cfg = json.loads(cfg_raw)
+cluster = cfg["clusters"][0]["cluster"]
+server = cluster["server"]
+ca_data = cluster["certificate-authority-data"]
+
+secret_raw = subprocess.check_output([
+    "kubectl", "--kubeconfig", admin,
+    "-n", "default", "get", "secret", "codex-mcp-token", "-o", "json",
+], text=True)
+secret = json.loads(secret_raw)
+token = base64.b64decode(secret["data"]["token"]).decode()
+
+out.write_text(f"""apiVersion: v1
+kind: Config
+clusters:
+  - name: talos-lab
+    cluster:
+      server: {json.dumps(server)}
+      certificate-authority-data: {json.dumps(ca_data)}
+users:
+  - name: codex-mcp
+    user:
+      token: {json.dumps(token)}
+contexts:
+  - name: codex-mcp@talos-lab
+    context:
+      cluster: talos-lab
+      user: codex-mcp
+      namespace: default
+current-context: codex-mcp@talos-lab
+""")
+out.chmod(stat.S_IRUSR | stat.S_IWUSR)
+print(f"wrote {out}")
+PY
+```
+
+Verify the restricted kubeconfig directly:
+
+```bash
+KUBECONFIG="$MCP_KUBECONFIG" kubectl auth can-i get pods -A
+KUBECONFIG="$MCP_KUBECONFIG" kubectl auth can-i get secrets -A
+KUBECONFIG="$MCP_KUBECONFIG" kubectl auth can-i create pods --subresource=exec -n default
+```
+
+Expected:
+
+```text
+yes
+no
+yes
+```
+
+Once the restricted kubeconfig is copied to the remote agent VM and verified,
+remove the admin kubeconfig from places where the agent can read it.
+
+## Short-lived alternative
+
+If you want a temporary token instead of the durable Secret, do not read
+`codex-mcp-token`. Mint a bounded token and write the same kubeconfig shape:
+
+```bash
+ADMIN_KUBECONFIG=.private/talos-vm-lab/kubeconfig
+KUBECONFIG="$ADMIN_KUBECONFIG" \
+  kubectl -n default create token codex-mcp --duration=24h
+```
+
+Use that token only in a local ignored kubeconfig, and rotate it by creating a
+new token when needed.
+
+## Cleanup
+
+For a disposable lab cluster:
+
+```bash
+KUBECONFIG=.private/talos-vm-lab/kubeconfig \
+  kubectl delete -f tests/manual/talos-codex-mcp-access.yaml --ignore-not-found
+
+rm -f .private/talos-vm-lab/codex-mcp.kubeconfig
+```

--- a/tests/manual/talos-codex-mcp-access.yaml
+++ b/tests/manual/talos-codex-mcp-access.yaml
@@ -1,0 +1,193 @@
+---
+# Manual-only bootstrap RBAC for a disposable Talos lab cluster.
+#
+# This is intentionally stored under tests/manual/ so Flux will not reconcile it
+# into the production cluster. Apply it with the Talos lab admin kubeconfig after
+# the Talos control plane has been bootstrapped and a Kubernetes kubeconfig has
+# been exported with `talosctl kubeconfig`.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: codex-mcp
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: codex-mcp-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - events
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - services
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources:
+      - pods/log
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - ingressclasses
+      - networkpolicies
+    verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list"]
+  - apiGroups: ["events.k8s.io"]
+    resources:
+      - events
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - csidrivers
+      - csinodes
+      - storageclasses
+      - volumeattachments
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources:
+      - volumesnapshotclasses
+      - volumesnapshotcontents
+      - volumesnapshots
+    verbs: ["get", "list"]
+  - apiGroups: ["volsync.backube"]
+    resources:
+      - replicationsources
+      - replicationdestinations
+    verbs: ["get", "list"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources:
+      - kustomizations
+    verbs: ["get", "list"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources:
+      - helmreleases
+    verbs: ["get", "list"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - buckets
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs: ["get", "list"]
+  - apiGroups: ["notification.toolkit.fluxcd.io"]
+    resources:
+      - alerts
+      - providers
+      - receivers
+    verbs: ["get", "list"]
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificates
+      - certificaterequests
+      - clusterissuers
+      - issuers
+    verbs: ["get", "list"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources:
+      - challenges
+      - orders
+    verbs: ["get", "list"]
+  - apiGroups: ["ceph.rook.io"]
+    resources:
+      - cephblockpools
+      - cephclients
+      - cephclusters
+      - cephfilesystems
+      - cephnfses
+      - cephobjectrealms
+      - cephobjectstores
+      - cephobjectstoreusers
+      - cephobjectzonegroups
+      - cephobjectzones
+      - cephrbdmirrors
+    verbs: ["get", "list"]
+  - apiGroups: ["cilium.io"]
+    resources:
+      - ciliumbgpclusterconfigs
+      - ciliumbgpnodeconfigs
+      - ciliumbgppeerconfigs
+      - ciliumcidrgroups
+      - ciliumclusterwideenvoyconfigs
+      - ciliumendpoints
+      - ciliumenvoyconfigs
+      - ciliumidentities
+      - ciliuml2announcementpolicies
+      - ciliumloadbalancerippools
+      - ciliumnodes
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: codex-mcp-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: codex-mcp-read
+subjects:
+  - kind: ServiceAccount
+    name: codex-mcp
+    namespace: default
+---
+# A durable token Secret is convenient for a persistent remote agent VM because
+# the bootstrap/admin kubeconfig can be removed after this token is copied into a
+# local ignored kubeconfig. Use `kubectl create token codex-mcp --duration=...`
+# instead if you want a short-lived credential.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: codex-mcp-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: codex-mcp
+type: kubernetes.io/service-account-token
+---
+# Narrow exec access in default only. Add namespace-scoped Role/RoleBinding pairs
+# later for specific app namespaces if a restore drill needs non-interactive exec
+# there. Do not grant broad pod mutation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: codex-mcp-exec
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: codex-mcp-exec
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: codex-mcp-exec
+subjects:
+  - kind: ServiceAccount
+    name: codex-mcp
+    namespace: default


### PR DESCRIPTION
## Summary

- Reconcile the v3 rebuild/refactor docs with the latest Talos lab and Rook-Ceph/RBD smoke-test findings.
- Update the roadmap/current-state/open-questions posture: keep Rook-Ceph as the working default unless real-node disk or restore validation exposes a blocker; keep the Hyper-V Talos lab as a narrow smoke/restore lab.
- Add manual-only Talos Codex MCP access documentation and test manifest outside Flux reconciliation.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown relative-link check for touched docs
- YAML parse of `tests/manual/talos-codex-mcp-access.yaml`

## Safety notes

- Repo/docs/manual-only changes; no live production cluster access or mutation.
- Talos lab findings are captured from prior disposable-lab work; this PR does not apply manifests to the lab or production.
- No secrets, kubeconfigs, tokens, SOPS values, or Kubernetes Secret values are included.

## Follow-up

After this lands, continue from `main` and use a short-lived docs branch for the pre-cutover safety checklist before any real-node formatting or rebuild work.
